### PR TITLE
 fix eddystone packet header byte order

### DIFF
--- a/adafruit_ble/beacon.py
+++ b/adafruit_ble/beacon.py
@@ -151,6 +151,6 @@ class EddystoneURLBeacon(Beacon):
         adv_data.add_field(AdvertisingData.SERVICE_DATA_16_BIT_UUID,
                            b''.join((self._EDDYSTONE_ID,
                                      b'\x10',
-                                     struct.pack("<BB", url_scheme_num, tx_power),
+                                     struct.pack("<BB", tx_power, url_scheme_num),
                                      bytes(short_url, 'ascii'))))
         super().__init__(adv_data, interval)


### PR DESCRIPTION
I notice that is I set the tx power ,my app was not recognizing the URL in the Eddystone beacon.
Lookin at the spec

https://github.com/google/eddystone/tree/master/eddystone-url
I think the tx_power and url scheme fields are reversed
swapping them seems to work, my App now set the URL with a non-zero tx_power.

before , with tx_power = 0 it was still a "valid" url_scheme so it worked until tx_power was set.

reported by receiving app (IOS Locate Beacon)
before change
```
Tx_power - default = 0
UUID: FEAA Data: 10 03 00 61 64 61 66 72 75 2E 69 74 2F 34 30 36 32 
tx_power = -54
UUID: FEAA Data: 10 03 CA 61 64 61 66 72 75 2E 69 74 2F 34 30 36 32 
```

after change
```Tx_power - default = 0
UUID: FEAA Data: 10 00 03 61 64 61 66 72 75 2E 69 74 2F 34 30 36 32
tx_power = -54
UUID: FEAA Data: 10 CA 03 61 64 61 66 72 75 2E 69 74 2F 34 30 36 32 
```

