### PR TITLE
do not start advertising automatically; update examples; fix doc issues

### DIFF
--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -33,7 +33,7 @@ Implementation Notes
 
 **Hardware:**
 
-   inline format: "* `Adafruit Feather nRF52840 Express <https://www.adafruit.com/product/4062>`_"
+   Adafruit Feather nRF52840 Express <https://www.adafruit.com/product/4062>
 
 **Software and Dependencies:**
 

--- a/adafruit_ble/beacon.py
+++ b/adafruit_ble/beacon.py
@@ -74,7 +74,7 @@ class LocationBeacon(Beacon):
     Example::
 
         from adafruit_ble.beacon import LocationBeacon
-        from adafruit_ble.uuid import UUID
+        from bleio import UUID
         test_uuid = UUID('12345678-1234-1234-1234-123456789abc')
         test_company = 0xFFFF
         b = LocationBeacon(test_company, test_uuid, 123, 234, -54)

--- a/adafruit_ble/uart.py
+++ b/adafruit_ble/uart.py
@@ -69,8 +69,6 @@ class UARTServer:
         self._rx_buffer = CharacteristicBuffer(self._nus_rx_char,
                                                timeout=timeout, buffer_size=buffer_size)
 
-        self._periph.start_advertising()
-
     def start_advertising(self):
         """Start advertising the service. When a client connects, advertising will stop.
         When the client disconnects, restart advertising by calling ``start_advertising()`` again.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,3 +6,12 @@
 
 .. automodule:: adafruit_ble
    :members:
+
+.. automodule:: adafruit_ble.advertising
+   :members:
+
+.. automodule:: adafruit_ble.beacon
+   :members:
+
+.. automodule:: adafruit_ble.uart
+   :members:

--- a/examples/ble_uart_echo_test.py
+++ b/examples/ble_uart_echo_test.py
@@ -7,8 +7,9 @@ uart.start_advertising()
 while not uart.connected:
     pass
 
+# When the client disconnects, the program will exit.
 while uart.connected:
     # Returns b'' if nothing was read.
     one_byte = uart.read(1)
     if one_byte:
-        uart.write(bytes([one_byte]))
+        uart.write(one_byte)


### PR DESCRIPTION
- `UARTServer()` was still calling `.start_advertising()`. That should have been removed. The user should start advertising explicitly.
- Fix bugs in examples (including fixing #7).
- Fix doc bugs and missing entries in `api.rst`.
