### PR TITLE
Write in chunks of 20 bytes or less

### DIFF
--- a/adafruit_ble/uart.py
+++ b/adafruit_ble/uart.py
@@ -125,4 +125,8 @@ class UARTServer:
 
     def write(self, buf):
         """Write a buffer of bytes."""
-        self._nus_tx_char.value = buf
+        # We can only write 20 bytes at a time.
+        offset = 0
+        while offset < len(buf):
+            self._nus_tx_char.value = buf[offset:offset+20]
+            offset += 20


### PR DESCRIPTION
Fixes #10.

@dastels Could you test this? The sending now appears to be correct: it will send no more than 20 bytes at a time.

A BLE notification is sent after each write. If the receiver does not handle the writes fast enough, bytes will be dropped. I tested by sending 200 bytes to the Bluefruit LE Connect app, and it received all 200. But a slower receiver may need to implement some kind of flow control.