### PR TITLE
Add Example for print text from ble UART

### DIFF
--- a/examples/ble_uart_printmessage_test
+++ b/examples/ble_uart_printmessage_test
@@ -1,5 +1,4 @@
 import board
-import neopixel
 from adafruit_ble.uart import UARTServer
 
 # Adapted from "Getting Started with CircuitPython and Bluetooth Low Energy" by Kattni Rembor

--- a/examples/ble_uart_printmessage_test
+++ b/examples/ble_uart_printmessage_test
@@ -1,0 +1,27 @@
+import board
+import neopixel
+from adafruit_ble.uart import UARTServer
+
+# Adapted from "Getting Started with CircuitPython and Bluetooth Low Energy" by Kattni Rembor
+# from https://learn.adafruit.com/circuitpython-nrf52840/overview
+
+uart_server = UARTServer()
+    
+    
+while True:
+    uart_server.start_advertising()
+    while not uart_server.connected:
+        pass
+        
+    # Now we're connected
+     
+    while uart_server.connected:
+        if uart_server.in_waiting:
+            uartread = str(uart_server.readline())
+            # Remove the start indicator and the ending return /n 
+            message = uartread[2:-3]
+            print(message)
+
+
+    # If we got here, we lost the connection. Go up to the top and start
+    # advertising again and waiting for a connection.


### PR DESCRIPTION
There doesn't seem to be an example for this floating around that i could find, so here is one.

Takes a line from the uart_server, strips the formatting and prints the result. Could be useful for people implementing custom commands over UART as it shows the readline() function.