### PR TITLE
Python advertisement data

### DIFF
--- a/adafruit_ble/beacon.py
+++ b/adafruit_ble/beacon.py
@@ -36,7 +36,7 @@ from .advertising import AdvertisingPacket
 
 class Beacon:
     """Base class for Beacon advertisers."""
-    def __init__(self, advertising_packet, interval=1.0):
+    def __init__(self, advertising_packet):
         """Set up a beacon with the given AdvertisingPacket.
 
         :param AdvertisingPacket advertising_packet
@@ -49,7 +49,8 @@ class Beacon:
 
         :param float interval: Advertising interval in seconds
         """
-        self._broadcaster.start_advertising(self._advertising_packet.packet_bytes, interval=interval)
+        self._broadcaster.start_advertising(self._advertising_packet.packet_bytes,
+                                            interval=interval)
 
     def stop(self):
         """Turn off beacon."""

--- a/adafruit_ble/beacon.py
+++ b/adafruit_ble/beacon.py
@@ -40,14 +40,16 @@ class Beacon:
         """Set up a beacon with the given AdvertisingPacket.
 
         :param AdvertisingPacket advertising_packet
-        :param float interval: Advertising interval in seconds
         """
-        self._broadcaster = bleio.Broadcaster(interval)
+        self._broadcaster = bleio.Peripheral(name=None)
         self._advertising_packet = advertising_packet
 
-    def start(self):
-        """Turn on beacon."""
-        self._broadcaster.start_advertising(self._advertising_packet.packet_bytes)
+    def start(self, interval=1.0):
+        """Turn on beacon.
+
+        :param float interval: Advertising interval in seconds
+        """
+        self._broadcaster.start_advertising(self._advertising_packet.packet_bytes, interval=interval)
 
     def stop(self):
         """Turn off beacon."""
@@ -60,7 +62,7 @@ class LocationBeacon(Beacon):
     Used for Apple iBeacon, Nordic nRF Beacon, etc.
     """
     # pylint: disable=too-many-arguments
-    def __init__(self, company_id, uuid, major, minor, rssi, interval=1.0):
+    def __init__(self, company_id, uuid, major, minor, rssi):
         """Create a beacon with the given values.
 
         :param int company_id: 16-bit company id designating beacon specification owner
@@ -69,7 +71,6 @@ class LocationBeacon(Beacon):
         :param int major: 16-bit major number, such as a store number
         :param int minor: 16-bit minor number, such as a location within a store
         :param int rssi: Signal strength in dBm at 1m (signed 8-bit value)
-        :param float interval: Advertising interval in seconds
 
     Example::
 
@@ -93,7 +94,7 @@ class LocationBeacon(Beacon):
                 bytes(reversed(uuid.uuid128)),
                 # major and minor are big-endian.
                 struct.pack(">HHb", major, minor, rssi))))
-        super().__init__(adv, interval=interval)
+        super().__init__(adv)
 
 
 class EddystoneURLBeacon(Beacon):
@@ -127,12 +128,11 @@ class EddystoneURLBeacon(Beacon):
         '.gov',
     )
 
-    def __init__(self, url, tx_power=0, interval=1.0):
+    def __init__(self, url, tx_power=0):
         """Create a URL beacon with an encoded version of the url and a transmit power.
 
         :param url URL to encode. Must be short enough to fit after encoding.
         :param int tx_power: transmit power in dBm at 0 meters (8 bit signed value)
-        :param float interval: advertising interval in seconds
         """
 
         adv = AdvertisingPacket()
@@ -155,4 +155,4 @@ class EddystoneURLBeacon(Beacon):
                                 b'\x10',
                                 struct.pack("<bB", tx_power, url_scheme_num),
                                 bytes(short_url, 'ascii'))))
-        super().__init__(adv, interval)
+        super().__init__(adv)

--- a/adafruit_ble/scanner.py
+++ b/adafruit_ble/scanner.py
@@ -30,9 +30,7 @@ UART-style communication.
 """
 import struct
 
-import bleio.ScanEntry
-import bleio.Scanner
-import bleio.UUID
+import bleio
 
 from .advertising import AdvertisingPacket
 
@@ -68,7 +66,7 @@ class Scanner:
         :returns: advertising packets found
         :rtype: list of `adafruit_ble.ScanEntry` objects
         """
-        return [ScanEntry(entry) for entry in self._scanner.scan(timeout, interval, window)]
+        return [ScanEntry(entry) for entry in self._scanner.scan(timeout, interval=interval, window=window)]
 
 
 class ScanEntry:

--- a/adafruit_ble/scanner.py
+++ b/adafruit_ble/scanner.py
@@ -1,0 +1,151 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2019 Dan Halbert for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_ble.scanner`
+====================================================
+
+UART-style communication.
+
+* Author(s): Dan Halbert for Adafruit Industries
+
+"""
+import struct
+
+import bleio.ScanEntry
+import bleio.Scanner
+import bleio.UUID
+
+from .advertising import AdvertisingPacket
+
+class Scanner:
+    """
+    Scan for BLE device advertisements for a period of time. Return what was received.
+
+    Example::
+
+        from adafruit_ble.scanner import Scanner
+        scanner = Scanner()
+        scanner.Scan
+
+        # Wait for a connection.
+        while not uart.connected:
+            pass
+
+        uart.write('abc')
+    """
+
+    def __init__(self):
+        self._scanner = bleio.Scanner()
+
+    def scan(self, timeout, *, interval=0.1, window=0.1):
+        """Scan for advertisements from BLE devices.
+
+        :param int timeout: how long to scan for (in seconds)
+        :param float interval: the interval (in seconds) between the start
+           of two consecutive scan windows.
+           Must be in the range 0.0025 - 40.959375 seconds.
+        :param float window: the duration (in seconds) to scan a single BLE channel.
+          `window` must be <= `interval`.
+        :returns: advertising packets found
+        :rtype: list of `adafruit_ble.ScanEntry` objects
+        """
+        return [ScanEntry(entry) for entry in self._scanner.scan(timeout, interval, window)]
+
+
+class ScanEntry:
+    """
+    Information about a single transmission of data from a BLE device received by a `Scanner`.
+
+    :param bleio.ScanEntry entry: lower-level ScanEntry from a `bleio.Scanner`.
+
+    This constructor would normally only be used by `Scanner`.
+    """
+
+    def __init__(self, entry):
+        self._bleio_entry = entry
+
+    def item(self, item_type):
+        """Return the bytes in the advertising packet for given the element type.
+
+        :param int element_type: An integer designating an element type.
+           A number are defined in `AdvertisingPacket`, such as `AdvertisingPacket.TX_POWER`.
+        :returns: bytes that are the value for the given element type.
+           If the element type is not present in the packet, return ``None``.
+        """
+        i = 0
+        adv_bytes = self.advertisement_bytes
+        while i < len(adv_bytes):
+            item_length = adv_bytes[i]
+            if  item_type != adv_bytes[i+1]:
+                # Type doesn't match: skip to next item
+                i += item_length + 1
+            else:
+                return adv_bytes[i + 2:i + item_length]
+        return None
+
+    @property
+    def advertisement_bytes(self):
+        """The raw bytes of the received advertisement."""
+        return self._bleio_entry.raw_data
+
+    @property
+    def rssi(self):
+        """The signal strength of the device at the time of the scan. (read-only)."""
+        return self._bleio_entry.rssi
+
+    @property
+    def address(self):
+        """The address of the device. (read-only)."""
+        return self._bleio_entry.address
+
+    @property
+    def name(self):
+        """The name of the device. (read-only)"""
+        name = self.item(AdvertisingPacket.COMPLETE_LOCAL_NAME)
+        return name if name else self.item(AdvertisingPacket.SHORT_LOCAL_NAME)
+
+    @property
+    def service_uuids(self):
+        """List of all the service UUIDs in the advertisement."""
+        concat_uuids = self.item(AdvertisingPacket.ALL_16_BIT_SERVICE_UUIDS)
+        concat_uuids = concat_uuids if concat_uuids else self.item(
+            AdvertisingPacket.SOME_16_BIT_SERVICE_UUIDS)
+
+        uuid_values = []
+        if concat_uuids:
+            for i in range(0, len(uuid_values), 2):
+                uuid_values.append(struct.unpack("<H", concat_uuids[i:i+2]))
+
+        concat_uuids = self.item(AdvertisingPacket.ALL_128_BIT_SERVICE_UUIDS)
+        concat_uuids = concat_uuids if concat_uuids else self.item(
+            AdvertisingPacket.SOME_128_BIT_SERVICE_UUIDS)
+
+        if concat_uuids:
+            for i in range(0, len(uuid_values), 16):
+                uuid_values.append(concat_uuids[i:i+16])
+
+        return [bleio.UUID(value) for value in uuid_values]
+
+    @property
+    def manufacturer_specific_data(self):
+        """Manufacturer-specific data in the advertisement, returned as bytes."""
+        return self.item(AdvertisingPacket.MANUFACTURER_SPECIFIC_DATA)

--- a/adafruit_ble/scanner.py
+++ b/adafruit_ble/scanner.py
@@ -145,7 +145,7 @@ class ScanEntry:
 
         if concat_uuids:
             for i in range(0, len(concat_uuids), 2):
-                uuid_values.append(struct.unpack("<H", concat_uuids[i:i+2]))
+                uuid_values.extend(struct.unpack("<H", concat_uuids[i:i+2]))
 
         concat_uuids = self.item(AdvertisingPacket.ALL_128_BIT_SERVICE_UUIDS)
         concat_uuids = concat_uuids if concat_uuids else self.item(
@@ -155,7 +155,6 @@ class ScanEntry:
             for i in range(0, len(concat_uuids), 16):
                 uuid_values.append(concat_uuids[i:i+16])
 
-        print(uuid_values)
         return [bleio.UUID(value) for value in uuid_values]
 
     @property

--- a/adafruit_ble/scanner.py
+++ b/adafruit_ble/scanner.py
@@ -73,11 +73,10 @@ class Scanner:
 
 class ScanEntry:
     """
-    Information about a single transmission of data from a BLE device received by a `Scanner`.
+    Information about an advertising packet from a BLE device received by a `Scanner`.
 
-    :param bleio.ScanEntry entry: lower-level ScanEntry from a `bleio.Scanner`.
-
-    This constructor would normally only be used by `Scanner`.
+    :param bleio.ScanEntry entry: lower-level ScanEntry returned from `bleio.Scanner`.
+      This constructor is normally used only `Scanner`.
     """
 
     def __init__(self, entry):
@@ -96,7 +95,7 @@ class ScanEntry:
         while i < len(adv_bytes):
             item_length = adv_bytes[i]
             if  item_type != adv_bytes[i+1]:
-                # Type doesn't match: skip to next item
+                # Type doesn't match: skip to next item.
                 i += item_length + 1
             else:
                 return adv_bytes[i + 2:i + item_length]

--- a/adafruit_ble/scanner.py
+++ b/adafruit_ble/scanner.py
@@ -42,13 +42,7 @@ class Scanner:
 
         from adafruit_ble.scanner import Scanner
         scanner = Scanner()
-        scanner.Scan
-
-        # Wait for a connection.
-        while not uart.connected:
-            pass
-
-        uart.write('abc')
+        scan_entries = scanner.scan()
     """
 
     def __init__(self):

--- a/adafruit_ble/scanner.py
+++ b/adafruit_ble/scanner.py
@@ -42,7 +42,7 @@ class Scanner:
 
         from adafruit_ble.scanner import Scanner
         scanner = Scanner()
-        scan_entries = scanner.scan()
+        scan_entries = scanner.scan(3)  # scan for 3 seconds
     """
 
     def __init__(self):

--- a/adafruit_ble/uart.py
+++ b/adafruit_ble/uart.py
@@ -29,7 +29,7 @@ UART-style communication.
 
 """
 from bleio import UUID, Characteristic, Service, Peripheral, CharacteristicBuffer
-
+from .advertising import ServerAdvertisement
 
 class UARTServer:
     """
@@ -68,12 +68,13 @@ class UARTServer:
         self._periph = Peripheral((nus_uart_service,))
         self._rx_buffer = CharacteristicBuffer(self._nus_rx_char,
                                                timeout=timeout, buffer_size=buffer_size)
+        self._advertisement = ServerAdvertisement(self._periph)
 
     def start_advertising(self):
         """Start advertising the service. When a client connects, advertising will stop.
         When the client disconnects, restart advertising by calling ``start_advertising()`` again.
         """
-        self._periph.start_advertising()
+        self._periph.start_advertising(data=self._advertisement.data)
 
     def stop_advertising(self):
         """Stop advertising the service."""

--- a/adafruit_ble/uart.py
+++ b/adafruit_ble/uart.py
@@ -28,81 +28,11 @@ BLE UART-style communication. Common definitions.
 * Author(s): Dan Halbert for Adafruit Industries
 
 """
-from bleio import UUID, CharacteristicBuffer
+from bleio import UUID
 
-
-
-
-class UART:
-    """
-    Common superclass for Nordic UART Service (NUS) clients or servers.
-    Not for general use: use `UARTServer` and `UARTClient` for Peripheral and Central,
-    respectively.
-
-    :param read_characteristic Characteristic: Characteristic to read from
-    :param write_characteristic Characteristic: Characteristic to write to
-    :param int timeout:  the timeout in seconds to wait
-      for the first character and between subsequent characters
-    :param int buffer_size: buffer up to this many bytes.
-      If more bytes are received, older bytes will be discarded.
-    """
-
-    NUS_SERVICE_UUID = UUID("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
-    """Nordic UART Service UUID"""
-    NUS_RX_CHAR_UUID = UUID("6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
-    """Nordic UART Service RX Characteristic UUID"""
-    NUS_TX_CHAR_UUID = UUID("6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
-    """Nordic UART Service TX Characteristic UUID"""
-
-    def __init__(self, *, read_characteristic, write_characteristic, timeout=5.0, buffer_size=64):
-        self._read_char = read_characteristic
-        self._write_char = write_characteristic
-        self._read_buffer = CharacteristicBuffer(self._read_char,
-                                                 timeout=timeout, buffer_size=buffer_size)
-
-    def read(self, nbytes=None):
-        """
-        Read characters. If ``nbytes`` is specified then read at most that many bytes.
-        Otherwise, read everything that arrives until the connection times out.
-        Providing the number of bytes expected is highly recommended because it will be faster.
-
-        :return: Data read
-        :rtype: bytes or None
-        """
-        return self._read_buffer.read(nbytes)
-
-    def readinto(self, buf, nbytes=None):
-        """
-        Read bytes into the ``buf``. If ``nbytes`` is specified then read at most
-        that many bytes. Otherwise, read at most ``len(buf)`` bytes.
-
-        :return: number of bytes read and stored into ``buf``
-        :rtype: int or None (on a non-blocking error)
-        """
-        return self._read_buffer.readinto(buf, nbytes)
-
-    def readline(self):
-        """
-        Read a line, ending in a newline character.
-
-        :return: the line read
-        :rtype: int or None
-        """
-        return self._read_buffer.readline()
-
-    @property
-    def in_waiting(self):
-        """The number of bytes in the input buffer, available to be read."""
-        return self._read_buffer.in_waiting
-
-    def reset_input_buffer(self):
-        """Discard any unread characters in the input buffer."""
-        self._read_buffer.reset_input_buffer()
-
-    def write(self, buf):
-        """Write a buffer of bytes."""
-        # We can only write 20 bytes at a time.
-        offset = 0
-        while offset < len(buf):
-            self._write_char.value = buf[offset:offset+20]
-            offset += 20
+NUS_SERVICE_UUID = UUID("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
+"""Nordic UART Service UUID"""
+NUS_RX_CHAR_UUID = UUID("6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
+"""Nordic UART Service RX Characteristic UUID"""
+NUS_TX_CHAR_UUID = UUID("6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
+"""Nordic UART Service TX Characteristic UUID"""

--- a/adafruit_ble/uart_client.py
+++ b/adafruit_ble/uart_client.py
@@ -101,6 +101,9 @@ class UARTClient:
         :param float scan_time: scan for this many seconds.
         :return list of Address objects, or an empty list, if none found
         """
+        if not scanner:
+            scanner = Scanner()
+
         return [se.address for se in
                 ScanEntry.with_service_uuid(scanner.scan_unique(scan_time), NUS_SERVICE_UUID)]
 

--- a/adafruit_ble/uart_client.py
+++ b/adafruit_ble/uart_client.py
@@ -49,7 +49,8 @@ class UARTClient:
         uart_client = UARTClient()
         uart_addresses = uart_client.scan()
         if uart_addresses:
-            uart_client.connect(uarts[0].address, 5, service_uuids_whitelist=(UART.NUS_SERVICE_UUID,))
+            uart_client.connect(uarts[0].address, 5,
+                                service_uuids_whitelist=(UART.NUS_SERVICE_UUID,))
         else:
             raise Error("No UART servers found.")
 

--- a/adafruit_ble/uart_client.py
+++ b/adafruit_ble/uart_client.py
@@ -105,7 +105,7 @@ class UARTClient:
             scanner = Scanner()
 
         return [se.address for se in
-                ScanEntry.with_service_uuid(scanner.scan_unique(scan_time), NUS_SERVICE_UUID)]
+                ScanEntry.with_service_uuid(scanner.scan(scan_time), NUS_SERVICE_UUID)]
 
     def disconnect(self):
         """Disconnect from the peripheral."""

--- a/adafruit_ble/uart_client.py
+++ b/adafruit_ble/uart_client.py
@@ -91,7 +91,8 @@ class UARTClient:
                                                  timeout=self._timeout,
                                                  buffer_size=self._buffer_size)
 
-    def scan(self, scanner=None, scan_time=2):
+    @staticmethod
+    def scan(scanner=None, scan_time=2):
         """Scan for Peripherals advertising the Nordic UART Service,
         and return their addresses.
 

--- a/adafruit_ble/uart_client.py
+++ b/adafruit_ble/uart_client.py
@@ -49,7 +49,7 @@ class UARTClient:
         uart_client = UARTClient()
         uart_addresses = uart_client.scan()
         if uart_addresses:
-            uart_client.connect(uarts[0].address, 5, service_uuids=(UART.NUS_SERVICE_UUID,))
+            uart_client.connect(uarts[0].address, 5, service_uuids_whitelist=(UART.NUS_SERVICE_UUID,))
         else:
             raise Error("No UART servers found.")
 
@@ -69,7 +69,7 @@ class UARTClient:
         :param float/int timeout: Try to connect for ``timeout`` seconds.
            Not related to the timeout passed to ``UARTClient()``.
         """
-        self._central.connect(address, timeout, service_uuids=(NUS_SERVICE_UUID,))
+        self._central.connect(address, timeout, service_uuids_whitelist=(NUS_SERVICE_UUID,))
 
         # Connect succeeded. Get the remote characteristics we need, which were
         # found during discovery.

--- a/adafruit_ble/uart_client.py
+++ b/adafruit_ble/uart_client.py
@@ -1,0 +1,84 @@
+ # The MIT License (MIT)
+#
+# Copyright (c) 2019 Dan Halbert for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_ble.uart_client`
+====================================================
+
+UART-style communication by a Central as a GATT Client
+
+* Author(s): Dan Halbert for Adafruit Industries
+
+"""
+from bleio import Characteristic, Central
+from .uart import UART
+
+class UARTClient(UART):
+    """
+    Provide UART-like functionality via the Nordic NUS service.
+
+    :param int timeout:  the timeout in seconds to wait
+      for the first character and between subsequent characters.
+    :param int buffer_size: buffer up to this many bytes.
+      If more bytes are received, older bytes will be discarded.
+    :param str name: Name to advertise for server. If None, use default Peripheral name.
+
+    Example::
+
+        from adafruit_ble.uart_client import UARTClient
+        from adafruit_ble.scanner import Scanner, ScanEntry
+
+        scanner = Scanner()
+        uarts = ScanEntry.with_service_uuid(scanner.scan_unique(3), UART.NUS_SERVICE_UUID)
+        if not uarts:
+            raise ValueError("No UART for connection")
+
+        uart_client = UARTClient()
+        uart_client.connect(uarts[0].address, 5, service_uuids=(UART.NUS_SERVICE_UUID,))
+
+        uart_client.write('abc')
+    """
+
+    def __init__(self, *, timeout=5.0, buffer_size=64):
+        # Since we're remote we receive on tx and send on rx. The names
+        # are from the point of view of the server.
+        super().__init__(read_characteristic=Characteristic(UART.NUS_TX_CHAR_UUID),
+                         write_characteristic=Characteristic(UART.NUS_RX_CHAR_UUID),
+                         timeout=timeout, buffer_size=buffer_size)
+
+        self._central = Central()
+
+    @property
+    def connected(self):
+        """True if we are connected to a peripheral."""
+        return self._central.connected
+
+    def connect(self, address, timeout):
+        """Try to connect to the peripheral at the given address.
+
+        :param bleio.Address address: The address of the peripheral to connect to
+        :param float/int timeout: Try to connect for timeout seconds.
+        """
+        self._central.connect(address, timeout, service_uuids=(UART.NUS_SERVICE_UUID,))
+
+    def disconnect(self):
+        """Disconnect from the peripheral."""
+        self._central.disconnect()

--- a/adafruit_ble/uart_client.py
+++ b/adafruit_ble/uart_client.py
@@ -30,7 +30,7 @@ UART-style communication by a Central as a GATT Client
 """
 from bleio import Central, CharacteristicBuffer
 from .uart import NUS_SERVICE_UUID, NUS_RX_CHAR_UUID, NUS_TX_CHAR_UUID
-from .scanner import ScanEntry
+from .scanner import Scanner, ScanEntry
 
 class UARTClient:
     """
@@ -45,7 +45,6 @@ class UARTClient:
     Example::
 
         from adafruit_ble.uart_client import UARTClient
-        from adafruit_ble.scanner import Scanner, ScanEntry
 
         uart_client = UARTClient()
         uart_addresses = uart_client.scan()

--- a/adafruit_ble/uart_server.py
+++ b/adafruit_ble/uart_server.py
@@ -1,0 +1,83 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2018 Dan Halbert for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_ble.uart_server`
+====================================================
+
+UART-style communication: Peripheral acting as a GATT Server.
+
+* Author(s): Dan Halbert for Adafruit Industries
+
+"""
+from bleio import Characteristic, Service, Peripheral
+from .advertising import ServerAdvertisement
+from .uart import UART
+
+class UARTServer(UART):
+    """
+    Provide UART-like functionality via the Nordic NUS service.
+
+    :param int timeout:  the timeout in seconds to wait
+      for the first character and between subsequent characters.
+    :param int buffer_size: buffer up to this many bytes.
+      If more bytes are received, older bytes will be discarded.
+    :param str name: Name to advertise for server. If None, use default Peripheral name.
+
+    Example::
+
+        from adafruit_ble.uart_server import UARTServer
+        uart = UARTServer()
+        uart.start_advertising()
+
+        # Wait for a connection.
+        while not uart.connected:
+            pass
+
+        uart.write('abc')
+    """
+
+    def __init__(self, *, timeout=1.0, buffer_size=64, name=None):
+        read_char = Characteristic(UART.NUS_RX_CHAR_UUID, write=True, write_no_response=True)
+        write_char = Characteristic(UART.NUS_TX_CHAR_UUID, notify=True)
+        super().__init__(read_characteristic=read_char, write_characteristic=write_char,
+                         timeout=timeout, buffer_size=buffer_size)
+
+        nus_uart_service = Service(UART.NUS_SERVICE_UUID, (read_char, write_char))
+
+        self._periph = Peripheral((nus_uart_service,), name=name)
+        self._advertisement = ServerAdvertisement(self._periph)
+
+    def start_advertising(self):
+        """Start advertising the service. When a client connects, advertising will stop.
+        When the client disconnects, restart advertising by calling ``start_advertising()`` again.
+        """
+        self._periph.start_advertising(self._advertisement.advertising_data_bytes,
+                                       scan_response=self._advertisement.scan_response_bytes)
+
+    def stop_advertising(self):
+        """Stop advertising the service."""
+        self._periph.stop_advertising()
+
+    @property
+    def connected(self):
+        """True if someone connected to the server."""
+        return self._periph.connected

--- a/adafruit_ble/uuid.py
+++ b/adafruit_ble/uuid.py
@@ -1,0 +1,35 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2019 Dan Halbert for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+`adafruit_ble.uuid`
+====================================================
+
+BLE UUIDs
+
+* Author(s): Dan Halbert for Adafruit Industries
+
+"""
+
+from bleio import UUID as bleio_UUID
+
+UUID = bleio_UUID
+"""`adafruit_ble.UUID` is the same as `bleio.UUID`"""

--- a/examples/ble_demo_central.py
+++ b/examples/ble_demo_central.py
@@ -1,0 +1,48 @@
+"""
+Demonstration of a Bluefruit BLE Central. Connects to the first BLE UART peripheral it finds.
+Sends Bluefruit ColorPackets, read from three potentiometers, to the peripheral.
+"""
+
+import time
+
+import board
+from analogio import AnalogIn
+
+#from adafruit_bluefruit_connect.packet import Packet
+# Only the packet classes that are imported will be known to Packet.
+from adafruit_bluefruit_connect.color_packet import ColorPacket
+
+from adafruit_ble.scanner import Scanner
+from adafruit_ble.uart_client import UARTClient
+
+def scale(value):
+    """Scale an value from 0-65535 (AnalogIn range) to 0-255 (RGB range)"""
+    return int(value / 65535 * 255)
+
+scanner = Scanner()
+uart_client = UARTClient()
+uart_addresses = []
+
+# Keep trying to find a UART peripheral
+while not uart_addresses:
+    uart_addresses = uart_client.scan(scanner)
+
+a0 = AnalogIn(board.A0)
+a1 = AnalogIn(board.A1)
+a2 = AnalogIn(board.A2)
+
+while True:
+    uart_client.connect(uart_addresses[0], 5)
+    while uart_client.connected:
+        r = scale(a0.value)
+        g = scale(a1.value)
+        b = scale(a2.value)
+
+        color = (r, g, b)
+        print(color)
+        color_packet = ColorPacket(color)
+        try:
+            uart_client.write(color_packet.to_bytes())
+        except OSError:
+            pass
+        time.sleep(0.3)

--- a/examples/ble_demo_periph.py
+++ b/examples/ble_demo_periph.py
@@ -1,0 +1,36 @@
+"""
+Used with ble_demo_central.py. Receives Bluefruit LE ColorPackets from a central,
+and updates a NeoPixel FeatherWing to show the history of the received packets.
+"""
+
+import board
+import neopixel
+
+from adafruit_ble.uart_server import UARTServer
+from adafruit_bluefruit_connect.packet import Packet
+# Only the packet classes that are imported will be known to Packet.
+from adafruit_bluefruit_connect.color_packet import ColorPacket
+
+uart_server = UARTServer()
+
+NUM_PIXELS = 32
+np = neopixel.NeoPixel(board.D10, NUM_PIXELS, brightness=0.1)
+next_pixel = 0
+
+def mod(i):
+    """Wrap i to modulus NUM_PIXELS."""
+    return i % NUM_PIXELS
+
+while True:
+    # Advertise when not connected.
+    uart_server.start_advertising()
+    while not uart_server.connected:
+        pass
+
+    while uart_server.connected:
+        packet = Packet.from_stream(uart_server)
+        if isinstance(packet, ColorPacket):
+            print(packet.color)
+            np[next_pixel] = packet.color
+            np[mod(next_pixel + 1)] = (0, 0, 0)
+        next_pixel = (next_pixel + 1) % NUM_PIXELS

--- a/examples/ble_uart_echo_test.py
+++ b/examples/ble_uart_echo_test.py
@@ -1,4 +1,4 @@
-from adafruit_ble.uart import UARTServer
+from adafruit_ble.uart_server import UARTServer
 
 uart = UARTServer()
 


### PR DESCRIPTION
These `adafruit_ble` library updates are necessary for https://github.com/adafruit/circuitpython/pull/1993 (bleio revamp and addition of central).

- Server advertisement data now construction in `adafruit_ble.advertising` instead of in C in `bleio`.
- Peripheral now subsumes Broadcaster, so code in `adafruit_ble.beacon` has changed.
- Add `adafruit_ble.scanner.Scanner` and `ScanEntry`, which wrap `bleio.Scanner` and `bleio.ScanEntry`, and add additional functionality.
- Move `adafruit_ble.uart.UARTServer` to  `adafruit_ble.uart_server.UARTServer`.
- Add `adafruit_ble.uart_client.UARTClient` to provide UART functionality as a BLE central.