### PR TITLE
Adding CircuitPython color picker example code

### DIFF
--- a/examples/ble_color_picker.py
+++ b/examples/ble_color_picker.py
@@ -1,0 +1,23 @@
+# CircuitPython NeoPixel Color Picker Example
+
+import board
+import neopixel
+from adafruit_ble.uart_server import UARTServer
+from adafruit_bluefruit_connect.packet import Packet
+from adafruit_bluefruit_connect.color_packet import ColorPacket
+
+uart_server = UARTServer()
+
+pixels = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.1)
+
+while True:
+    # Advertise when not connected.
+    uart_server.start_advertising()
+    while not uart_server.connected:
+        pass
+
+    while uart_server.connected:
+        packet = Packet.from_stream(uart_server)
+        if isinstance(packet, ColorPacket):
+            print(packet.color)
+            pixels.fill(packet.color)


### PR DESCRIPTION
Adding general CircuitPython color picker example to use with other boards. Meant for inclusion in Getting Started with CP and BLE guide. Would prefer separate examples for this guide and the CPB guide, and have submitted this separately for that reason. Understanding API will change.