### PR TITLE
doc and cleanup pass

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,12 +31,12 @@ Usage Example
 
 .. code-block:: python
 
-    from adafruit_ble import SmartAdapter
+    from adafruit_ble import BLERadio
 
-    adapter = SmartAdapter()
+    radio = BLERadio()
     print("scanning")
     found = set()
-    for entry in adapter.start_scan(timeout=60, minimum_rssi=-80):
+    for entry in radio.start_scan(timeout=60, minimum_rssi=-80):
         addr = entry.address
         if addr not in found:
             print(entry)

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -58,8 +58,8 @@ class BLEConnection:
     Represents a connection to a peer BLE device.
     It acts as a map from a `Service` type to a `Service` instance for the connection.
 
-    :param bleio_connection _bleio.Connection
-      Wrap the native `_bleio.Connection` object.
+    :param bleio_connection _bleio.Connection: the native `_bleio.Connection` object to wrap
+
     """
     def __init__(self, bleio_connection):
         self._bleio_connection = bleio_connection

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -35,6 +35,7 @@ Implementation Notes
 **Hardware:**
 
    Adafruit Feather nRF52840 Express <https://www.adafruit.com/product/4062>
+   Adafruit Circuit Playground Bluefruit <https://www.adafruit.com/product/4333>
 
 **Software and Dependencies:**
 
@@ -53,46 +54,60 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 class BLEConnection:
-    """This represents a connection to a peer BLE device.
-
-       It acts as a map from a Service type to a Service instance for the connection.
     """
-    def __init__(self, connection):
-        self._connection = connection
-        self._discovered_services = {}
-        """These are the bare remote services from _bleio."""
+    Represents a connection to a peer BLE device.
+    It acts as a map from a `Service` type to a `Service` instance for the connection.
 
+    :param bleio_connection _bleio.connection
+    """
+    def __init__(self, bleio_connection):
+        self._bleio_connection = bleio_connection
+        # _bleio.Service objects representing services found during discoery.
+        self._discovered_bleio_services = {}
+        # Service objects that wrap remote services.
         self._constructed_services = {}
-        """These are the Service instances from the library that wrap the remote services."""
 
     def _discover_remote(self, uuid):
         remote_service = None
-        if uuid in self._discovered_services:
-            remote_service = self._discovered_services[uuid]
+        if uuid in self._discovered_bleio_services:
+            remote_service = self._discovered_bleio_services[uuid]
         else:
-            results = self._connection.discover_remote_services((uuid.bleio_uuid,))
+            results = self._bleio_connection.discover_remote_services((uuid.bleio_uuid,))
             if results:
                 remote_service = results[0]
-                self._discovered_services[uuid] = remote_service
+                self._discovered_bleio_services[uuid] = remote_service
         return remote_service
 
     def __contains__(self, key):
+        """
+        Allows easy testing for a particular Service class or a particular UUID
+        associated with this connection.
+
+        Example::
+
+            if UARTService in connection:
+                # do something
+
+            if StandardUUID(0x1234) in connection:
+                # do something
+        """
         uuid = key
         if hasattr(key, "uuid"):
             uuid = key.uuid
         return self._discover_remote(uuid) is not None
 
     def __getitem__(self, key):
+        """Return the Service for the given Service class or uuid, if any."""
         uuid = key
         maybe_service = False
         if hasattr(key, "uuid"):
             uuid = key.uuid
             maybe_service = True
 
-        remote_service = self._discover_remote(uuid)
-
         if uuid in self._constructed_services:
             return self._constructed_services[uuid]
+
+        remote_service = self._discover_remote(uuid)
         if remote_service:
             constructed_service = None
             if maybe_service:
@@ -105,16 +120,19 @@ class BLEConnection:
     @property
     def connected(self):
         """True if the connection to the peer is still active."""
-        return self._connection.connected
+        return self._bleio_connection.connected
 
     def disconnect(self):
         """Disconnect from peer."""
-        self._connection.disconnect()
+        self._bleio_connection.disconnect()
 
 class BLERadio:
-    """The BLERadio class enhances the normal `_bleio.Adapter`.
+    """
+    BLERadio provides the interfaces for BLE advertising,
+    scanning for advertisements, and connecting to peers. There may be
+    multiple connections active at once.
 
-       It uses the library's `Advertisement` classes and the `BLEConnection` class."""
+    It uses this library's `Advertisement` classes and the `BLEConnection` class."""
 
     def __init__(self, adapter=None):
         if not adapter:
@@ -123,34 +141,62 @@ class BLERadio:
         self._current_advertisement = None
         self._connection_cache = {}
 
-    def start_advertising(self, advertisement, scan_response=None, **kwargs):
-        """Starts advertising the given advertisement.
+    def start_advertising(self, advertisement, scan_response=None, interval=0.1):
+        """
+        Starts advertising the given advertisement.
 
-            It takes most kwargs of `_bleio.Adapter.start_advertising`."""
+        :param buf scan_response: scan response data packet bytes.
+            ``None`` if no scan response is needed.
+        :param float interval:  advertising interval, in seconds
+        """
         scan_response_data = None
         if scan_response:
             scan_response_data = bytes(scan_response)
         self._adapter.start_advertising(bytes(advertisement),
                                         scan_response=scan_response_data,
                                         connectable=advertisement.connectable,
-                                        **kwargs)
+                                        interval=interval)
 
     def stop_advertising(self):
         """Stops advertising."""
         self._adapter.stop_advertising()
 
-    def start_scan(self, *advertisement_types, **kwargs):
-        """Starts scanning. Returns an iterator of advertisement objects of the types given in
-           advertisement_types. The iterator will block until an advertisement is heard or the scan
-           times out.
+    def start_scan(self, *advertisement_types, buffer_size=512, extended=False, timeout=None,
+                   interval=0.1, window=0.1, minimum_rssi=-80, active=True):
+        """
+        Starts scanning. Returns an iterator of advertisement objects of the types given in
+        advertisement_types. The iterator will block until an advertisement is heard or the scan
+        times out.
 
-           If any ``advertisement_types`` are given, only Advertisements of those types are produced
-           by the returned iterator. If none are given then `Advertisement` objects will be
-           returned."""
+        If any ``advertisement_types`` are given, only Advertisements of those types are produced
+        by the returned iterator. If none are given then `Advertisement` objects will be
+        returned.
+
+        Advertisements and scan responses are filtered and returned separately.
+
+        :param int buffer_size: the maximum number of advertising bytes to buffer.
+        :param bool extended: When True, support extended advertising packets.
+            Increasing buffer_size is recommended when this is set.
+        :param float timeout: the scan timeout in seconds.
+            If None, will scan until `stop_scan` is called.
+        :param float interval: the interval (in seconds) between the start
+             of two consecutive scan windows
+             Must be in the range 0.0025 - 40.959375 seconds.
+        :param float window: the duration (in seconds) to scan a single BLE channel.
+             window must be <= interval.
+        :param int minimum_rssi: the minimum rssi of entries to return.
+        :param bool active: request and retrieve scan responses for scannable advertisements.
+        :returns: iterable: If any ``advertisement_types`` are given,
+           only Advertisements of those types are produced by the returned iterator.
+           If none are given then `Advertisement` objects will be returned.
+        """
         prefixes = b""
         if advertisement_types:
             prefixes = b"".join(adv.prefix for adv in advertisement_types)
-        for entry in self._adapter.start_scan(prefixes=prefixes, **kwargs):
+        for entry in self._adapter.start_scan(prefixes=prefixes, buffer_size=buffer_size,
+                                              extended=extended, timeout=timeout,
+                                              interval=interval, window=window,
+                                              minimum_rssi=minimum_rssi, active=active):
             adv_type = Advertisement
             for possible_type in advertisement_types:
                 if possible_type.matches(entry) and issubclass(possible_type, adv_type):
@@ -167,7 +213,14 @@ class BLERadio:
         self._adapter.stop_scan()
 
     def connect(self, advertisement, *, timeout=4):
-        """Initiates a `BLEConnection` to the peer that advertised the given advertisement."""
+        """
+        Initiates a `BLEConnection` to the peer that advertised the given advertisement.
+
+        :param advertisement Advertisement: An `Advertisement` or a subclass of `Advertisement`
+        :param timeout float: how long to wait for a connection
+        :returns the connection to the peer
+        :rtype BLEConnection
+        """
         connection = self._adapter.connect(advertisement.address, timeout=timeout)
         self._connection_cache[connection] = BLEConnection(connection)
         return self._connection_cache[connection]

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -58,11 +58,12 @@ class BLEConnection:
     Represents a connection to a peer BLE device.
     It acts as a map from a `Service` type to a `Service` instance for the connection.
 
-    :param bleio_connection _bleio.connection
+    :param bleio_connection _bleio.Connection
+      Wrap the native `_bleio.Connection` object.
     """
     def __init__(self, bleio_connection):
         self._bleio_connection = bleio_connection
-        # _bleio.Service objects representing services found during discoery.
+        # _bleio.Service objects representing services found during discovery.
         self._discovered_bleio_services = {}
         # Service objects that wrap remote services.
         self._constructed_services = {}
@@ -186,9 +187,10 @@ class BLERadio:
              window must be <= interval.
         :param int minimum_rssi: the minimum rssi of entries to return.
         :param bool active: request and retrieve scan responses for scannable advertisements.
-        :returns: iterable: If any ``advertisement_types`` are given,
+        :return: If any ``advertisement_types`` are given,
            only Advertisements of those types are produced by the returned iterator.
            If none are given then `Advertisement` objects will be returned.
+        :rtype: iterable
         """
         prefixes = b""
         if advertisement_types:
@@ -218,8 +220,8 @@ class BLERadio:
 
         :param advertisement Advertisement: An `Advertisement` or a subclass of `Advertisement`
         :param timeout float: how long to wait for a connection
-        :returns the connection to the peer
-        :rtype BLEConnection
+        :return: the connection to the peer
+        :rtype: BLEConnection
         """
         connection = self._adapter.connect(advertisement.address, timeout=timeout)
         self._connection_cache[connection] = BLEConnection(connection)

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -25,15 +25,13 @@ Advertising is the first phase of BLE where devices can broadcast
 
 import struct
 
-def to_hex(b):
+def to_hex(seq):
     """Pretty prints a byte sequence as hex values."""
-    # pylint: disable=invalid-name
-    return " ".join(["{:02x}".format(v) for v in b])
+    return " ".join("{:02x}".format(v) for v in seq)
 
-def to_bytes_literal(b):
+def to_bytes_literal(seq):
     """Prints a byte sequence as a Python bytes literal that only uses hex encoding."""
-    # pylint: disable=invalid-name
-    return "b\"" + "".join(["\\x{:02x}".format(v) for v in b]) + "\""
+    return "b\"" + "".join("\\x{:02x}".format(v) for v in seq) + "\""
 
 def decode_data(data, *, key_encoding="B"):
     """Helper which decodes length encoded structures into a dictionary with the given key

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -64,7 +64,8 @@ class BoundServiceList:
         return uuid in self._vendor_services or uuid in self._standard_services
 
     def _update(self, adt, uuids):
-        if len(uuids) == 0:
+        if not uuids:
+            # uuids is empty
             del self._advertisement.data_dict[adt]
         uuid_length = uuids[0].size // 8
         b = bytearray(len(uuids) * uuid_length)
@@ -131,12 +132,12 @@ class ServiceList(AdvertisingDataField):
     def __get__(self, obj, cls):
         if not self._present(obj) and not obj.mutable:
             return None
-        if not hasattr(obj, "_service_lists"):
-            obj._service_lists = {}
+        if not hasattr(obj, "adv_service_lists"):
+            obj.adv_service_lists = {}
         first_adt = self.standard_services[0]
-        if first_adt not in obj._service_lists:
-            obj._service_lists[first_adt] = BoundServiceList(obj, **self.__dict__)
-        return obj._service_lists[first_adt]
+        if first_adt not in obj.adv_service_lists:
+            obj.adv_service_lists[first_adt] = BoundServiceList(obj, **self.__dict__)
+        return obj.adv_service_lists[first_adt]
 
 class ProvideServicesAdvertisement(Advertisement):
     """Advertise what services that the device makes available upon connection."""

--- a/adafruit_ble/attributes/__init__.py
+++ b/adafruit_ble/attributes/__init__.py
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2019 Scott Shawcroft for Adafruit Industries
+# Copyright (c) 2019 Dan Halbert for Adafruit Industries
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,34 +20,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 """
-`circuitpython`
+:py:mod:`~adafruit_ble.attributes`
 ====================================================
 
-This module provides Services defined by CircuitPython. **Out of date.**
+This module provides definitions common to all kinds of BLE attributes,
+specifically characteristics and descriptors.
 
 """
-
-from . import Service
-from ..characteristics import Characteristic
-from ..characteristics.stream import StreamOut
-from ..characteristics.string import StringCharacteristic
-from ..uuid import VendorUUID
+import _bleio
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
-class CircuitPythonUUID(VendorUUID):
-    """UUIDs with the CircuitPython base UUID."""
-    def __init__(self, uuid16):
-        uuid128 = bytearray("nhtyPtiucriC".encode("utf-8") + b"\x00\x00\xaf\xad")
-        uuid128[-3] = uuid16 >> 8
-        uuid128[-4] = uuid16 & 0xff
-        super().__init__(uuid128)
-
-class CircuitPythonService(Service):
-    """Core CircuitPython service that allows for file modification and REPL access.
-       Unimplemented."""
-    uuid = CircuitPythonUUID(0x0100)
-    filename = StringCharacteristic(uuid=CircuitPythonUUID(0x0200),
-                                    properties=(Characteristic.READ | Characteristic.WRITE))
-    contents = StreamOut(uuid=CircuitPythonUUID(0x0201))
+class Attribute:
+    """Constants describing security levels."""
+    NO_ACCESS = _bleio.Attribute.NO_ACCESS
+    OPEN = _bleio.Attribute.OPEN
+    ENCRYPT_NO_MITM = _bleio.Attribute.ENCRYPT_NO_MITM
+    ENCRYPT_WITH_MITM = _bleio.Attribute.ENCRYPT_WITH_MITM
+    LESC_ENCRYPT_WITH_MITM = _bleio.Attribute.LESC_ENCRYPT_WITH_MITM
+    SIGNED_NO_MITM = _bleio.Attribute.SIGNED_NO_MITM
+    SIGNED_WITH_MITM = _bleio.Attribute.SIGNED_NO_MITM

--- a/adafruit_ble/attributes/__init__.py
+++ b/adafruit_ble/attributes/__init__.py
@@ -33,7 +33,36 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 class Attribute:
-    """Constants describing security levels."""
+    """Constants describing security levels.
+
+      .. data:: NO_ACCESS
+
+         security mode: access not allowed
+
+      .. data:: OPEN
+
+         security_mode: no security (link is not encrypted)
+
+      .. data:: ENCRYPT_NO_MITM
+
+         security_mode: unauthenticated encryption, without man-in-the-middle protection
+
+      .. data:: ENCRYPT_WITH_MITM
+
+         security_mode: authenticated encryption, with man-in-the-middle protection
+
+      .. data:: LESC_ENCRYPT_WITH_MITM
+
+         security_mode: LESC encryption, with man-in-the-middle protection
+
+      .. data:: SIGNED_NO_MITM
+
+         security_mode: unauthenticated data signing, without man-in-the-middle protection
+
+      .. data:: SIGNED_WITH_MITM
+
+         security_mode: authenticated data signing, without man-in-the-middle protection
+"""
     NO_ACCESS = _bleio.Attribute.NO_ACCESS
     OPEN = _bleio.Attribute.OPEN
     ENCRYPT_NO_MITM = _bleio.Attribute.ENCRYPT_NO_MITM

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -39,6 +39,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class Characteristic:
     """
     Top level Characteristic class that does basic binding.
+
     :param UUID uuid: The uuid of the characteristic
     :param int properties: The properties of the characteristic,
        specified as a bitmask of these values bitwise-or'd together:
@@ -57,24 +58,37 @@ class Characteristic:
     :param bool fixed_length: True if the characteristic value is of fixed length.
     :param buf initial_value: The initial value for this characteristic. If not given, will be
        filled with zeros.
-    :return: the new Characteristic.
 
+    .. data:: BROADCAST
+
+       property: allowed in advertising packets
+
+    .. data:: INDICATE
+
+         property: server will indicate to the client when the value is set and wait for a response
+
+    .. data:: NOTIFY
+
+       property: server will notify the client when the value is set
+
+    .. data:: READ
+
+       property: clients may read this characteristic
+
+    .. data:: WRITE
+
+       property: clients may write this characteristic; a response will be sent back
+
+    .. data:: WRITE_NO_RESPONSE
+
+       property: clients may write this characteristic; no response will be sent back
 """
     BROADCAST = _bleio.Characteristic.BROADCAST
-    """Property: allowed in advertising packets."""
     INDICATE = _bleio.Characteristic.INDICATE
-    """Property: server will indicate to the client when the value is set
-    and wait for a response.
-    """
     NOTIFY = _bleio.Characteristic.NOTIFY
-    """Property: lServer will notify the client when the value is set."""
     READ = _bleio.Characteristic.READ
-    """Property: clients may read this characteristic."""
     WRITE = _bleio.Characteristic.WRITE
-    """Property: clients may write this characteristic; a response will be sent back."""
     WRITE_NO_RESPONSE = _bleio.Characteristic.WRITE_NO_RESPONSE
-    """Property: clients may write this characteristic; no response will be sent back."""
-
 
     def __init__(self, *, uuid=None, properties=0,
                  read_perm=Attribute.OPEN, write_perm=Attribute.OPEN,

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -27,6 +27,7 @@ This module provides float characteristics that are usable directly as attribute
 
 """
 
+from . import Attribute
 from . import StructCharacteristic
 
 __version__ = "0.0.0-auto.0"
@@ -34,11 +35,14 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 class FloatCharacteristic(StructCharacteristic):
     """32-bit float"""
-    # TODO: Valid set values as within range.
-    def __init__(self, **kwargs):
-        if "initial_value" in kwargs:
-            kwargs["initial_value"] = (kwargs["initial_value"],)
-        super().__init__("<f", **kwargs)
+    def __init__(self, *, uuid=None, properties=0,
+                 read_perm=Attribute.OPEN, write_perm=Attribute.OPEN,
+                 initial_value=None):
+        if initial_value:
+            initial_value = (initial_value,)
+        super().__init__("<f", uuid=uuid, properties=properties,
+                         read_perm=read_perm, write_perm=write_perm,
+                         initial_value=initial_value)
 
     def __get__(self, obj, cls=None):
         return super().__get__(obj)[0]

--- a/adafruit_ble/characteristics/int.py
+++ b/adafruit_ble/characteristics/int.py
@@ -27,20 +27,28 @@ This module provides integer characteristics that are usable directly as attribu
 
 """
 
+from . import Attribute
 from . import StructCharacteristic
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
-class Uint8Characteristic(StructCharacteristic):
-    """Uint8 number."""
-    # TODO: Valid set values as within range.
-    def __init__(self, *, min_value=0, max_value=255, **kwargs):
+class IntCharacteristic(StructCharacteristic):
+    """Superclass for different kinds of integer fields."""
+    def __init__(self, format_string, min_value, max_value, *, uuid=None, properties=0,
+                 read_perm=Attribute.OPEN, write_perm=Attribute.OPEN,
+                 initial_value=None):
         self._min_value = min_value
         self._max_value = max_value
-        if "initial_value" in kwargs:
-            kwargs["initial_value"] = (kwargs["initial_value"],)
-        super().__init__("<B", **kwargs)
+        if initial_value:
+            initial_value = (initial_value,)
+            if not self._min_value <= initial_value <= self._max_value:
+                raise ValueError("initial_value out of range")
+
+
+        super().__init__(format_string, uuid=uuid, properties=properties,
+                         read_perm=read_perm, write_perm=write_perm,
+                         initial_value=initial_value)
 
     def __get__(self, obj, cls=None):
         return super().__get__(obj)[0]
@@ -49,3 +57,33 @@ class Uint8Characteristic(StructCharacteristic):
         if not self._min_value <= value <= self._max_value:
             raise ValueError("out of range")
         super().__set__(obj, (value,))
+
+class Int8Characteristic(IntCharacteristic):
+    """Int8 number."""
+    def __init__(self, *, min_value=-128, max_value=127, **kwargs):
+        super().__init__("<b", min_value, max_value, **kwargs)
+
+class Uint8Characteristic(IntCharacteristic):
+    """Uint8 number."""
+    def __init__(self, *, min_value=0, max_value=0xff, **kwargs):
+        super().__init__("<B", min_value, max_value, **kwargs)
+
+class Int16Characteristic(IntCharacteristic):
+    """Int16 number."""
+    def __init__(self, *, min_value=-32768, max_value=32767, **kwargs):
+        super().__init__("<h", min_value, max_value, **kwargs)
+
+class Uint16Characteristic(IntCharacteristic):
+    """Uint16 number."""
+    def __init__(self, *, min_value=0, max_value=0xffff, **kwargs):
+        super().__init__("<H", min_value, max_value, **kwargs)
+
+class Int32Characteristic(IntCharacteristic):
+    """Int32 number."""
+    def __init__(self, *, min_value=-2147483648, max_value=2147483647, **kwargs):
+        super().__init__("<i", min_value, max_value, **kwargs)
+
+class Uint32Characteristic(IntCharacteristic):
+    """Uint32 number."""
+    def __init__(self, *, min_value=0, max_value=0xffffffff, **kwargs):
+        super().__init__("<I", min_value, max_value, **kwargs)

--- a/adafruit_ble/characteristics/stream.py
+++ b/adafruit_ble/characteristics/stream.py
@@ -27,8 +27,10 @@ This module provides stream characteristics that bind readable or writable objec
 object they are on.
 
 """
-
 import _bleio
+
+from . import Attribute
+from . import Characteristic
 from . import ComplexCharacteristic
 
 __version__ = "0.0.0-auto.0"
@@ -49,12 +51,13 @@ class BoundWriteStream:
 
 class StreamOut(ComplexCharacteristic):
     """Output stream from the Service server."""
-    def __init__(self, *, timeout=1.0, buffer_size=64, **kwargs):
+    def __init__(self, *, uuid=None, timeout=1.0, buffer_size=64,
+                 properties=Characteristic.NOTIFY,
+                 read_perm=Attribute.OPEN, write_perm=Attribute.OPEN):
         self._timeout = timeout
         self._buffer_size = buffer_size
-        super().__init__(properties=_bleio.Characteristic.NOTIFY,
-                         read_perm=_bleio.Attribute.OPEN,
-                         **kwargs)
+        super().__init__(uuid=uuid, properties=properties,
+                         read_perm=read_perm, write_perm=write_perm)
 
     def bind(self, service):
         """Binds the characteristic to the given Service."""
@@ -69,14 +72,14 @@ class StreamOut(ComplexCharacteristic):
 
 class StreamIn(ComplexCharacteristic):
     """Input stream into the Service server."""
-    def __init__(self, *, timeout=1.0, buffer_size=64, **kwargs):
+    def __init__(self, *, uuid=None, timeout=1.0, buffer_size=64,
+                 properties=(Characteristic.WRITE | Characteristic.WRITE_NO_RESPONSE),
+                 write_perm=Attribute.OPEN):
         self._timeout = timeout
         self._buffer_size = buffer_size
-        super().__init__(properties=(_bleio.Characteristic.WRITE |
-                                     _bleio.Characteristic.WRITE_NO_RESPONSE),
-                         read_perm=_bleio.Attribute.NO_ACCESS,
-                         write_perm=_bleio.Attribute.OPEN,
-                         **kwargs)
+        super().__init__(uuid=uuid, properties=properties,
+                         read_perm=Attribute.NO_ACCESS,
+                         write_perm=write_perm)
 
     def bind(self, service):
         """Binds the characteristic to the given Service."""

--- a/adafruit_ble/characteristics/string.py
+++ b/adafruit_ble/characteristics/string.py
@@ -27,7 +27,7 @@ This module provides string characteristics.
 
 """
 
-import _bleio
+from . import Attribute
 from . import Characteristic
 
 __version__ = "0.0.0-auto.0"
@@ -35,30 +35,27 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 class StringCharacteristic(Characteristic):
     """UTF-8 Encoded string characteristic."""
-    def __init__(self, *, properties=_bleio.Characteristic.READ, uuid=None):
-        super().__init__(properties=properties,
-                         read_perm=_bleio.Attribute.OPEN,
-                         max_length=512,
+    def __init__(self, *, uuid=None, properties=Characteristic.READ,
+                 read_perm=Attribute.OPEN, write_perm=Attribute.OPEN,
+                 initial_value=None):
+        super().__init__(uuid=uuid, properties=properties,
+                         read_perm=read_perm, write_perm=write_perm,
+                         max_length=510,  # shorter than 512 due to fixed_length==False
                          fixed_length=False,
-                         uuid=uuid)
+                         initial_value=initial_value)
 
     def __get__(self, obj, cls=None):
-        raw_data = super().__get__(obj, cls)
-        return str(raw_data, "utf-8")
+        return str(super().__get__(obj, cls), "utf-8")
 
     def __set__(self, obj, value):
-        encoded_value = value.encode("utf-8")
-        super().__set__(obj, encoded_value)
+        super().__set__(obj, value.encode("utf-8"))
 
 class FixedStringCharacteristic(Characteristic):
     """Fixed strings are set once when bound and unchanged after."""
-    def __init__(self, *, uuid=None):
-        super().__init__(properties=_bleio.Characteristic.READ,
-                         read_perm=_bleio.Attribute.OPEN,
-                         write_perm=_bleio.Attribute.NO_ACCESS,
-                         fixed_length=True,
-                         uuid=uuid)
+    def __init__(self, *, uuid=None, read_perm=Attribute.OPEN):
+        super().__init__(uuid=uuid, properties=Characteristic.READ,
+                         read_perm=read_perm, write_perm=Attribute.NO_ACCESS,
+                         fixed_length=True)
 
     def __get__(self, obj, cls=None):
-        raw_data = super().__get__(obj, cls)
-        return str(raw_data, "utf-8")
+        return str(super().__get__(obj, cls), "utf-8")

--- a/adafruit_ble/services/__init__.py
+++ b/adafruit_ble/services/__init__.py
@@ -70,6 +70,7 @@ class Service:
             if (not isinstance(value, Characteristic) and
                     not isinstance(value, ComplexCharacteristic)):
                 continue
+
             value.field_name = class_attr
 
             # Get or set every attribute to ensure that they are all bound up front. We could lazily

--- a/adafruit_ble/services/midi.py
+++ b/adafruit_ble/services/midi.py
@@ -27,8 +27,6 @@ This module provides Services defined by the MIDI group.
 
 """
 
-import _bleio
-
 from . import Service
 from ..uuid import VendorUUID
 from ..characteristics import Characteristic
@@ -40,10 +38,10 @@ class MidiIOCharacteristic(Characteristic):
     """Workhorse MIDI Characteristic that carries midi messages both directions. Unimplemented."""
     uuid = VendorUUID("7772E5DB-3868-4112-A1A9-F2669D106BF3")
     def __init__(self, **kwargs):
-        super().__init__(properties=(_bleio.Characteristic.NOTIFY |
-                                     _bleio.Characteristic.READ |
-                                     _bleio.Characteristic.WRITE |
-                                     _bleio.Characteristic.WRITE_NO_RESPONSE), **kwargs)
+        super().__init__(properties=(Characteristic.NOTIFY |
+                                     Characteristic.READ |
+                                     Characteristic.WRITE |
+                                     Characteristic.WRITE_NO_RESPONSE), **kwargs)
 
 class MidiService(Service):
     """BLE Service that transports MIDI messages. Unimplemented."""

--- a/adafruit_ble/services/nordic.py
+++ b/adafruit_ble/services/nordic.py
@@ -44,19 +44,7 @@ class UARTService(Service):
     :param int buffer_size: buffer up to this many bytes.
       If more bytes are received, older bytes will be discarded.
 
-    Example::
-
-        from adafruit_ble.uart_client import UARTClient
-
-        uart_client = UARTClient()
-        uart_addresses = uart_client.scan()
-        if uart_addresses:
-            uart_client.connect(uarts[0].address, 5,
-                                service_uuids_whitelist=(UART.NUS_SERVICE_UUID,))
-        else:
-            raise Error("No UART servers found.")
-
-        uart_client.write('abc')
+    See ``examples/ble_uart_echo_test.py`` for a usage example.
     """
     # pylint: disable=no-member
     uuid = VendorUUID("6E400001-B5A3-F393-E0A9-E50E24DCCA9E")
@@ -102,7 +90,7 @@ class UARTService(Service):
         Read a line, ending in a newline character.
 
         :return: the line read
-        :rtype: int or None
+        :rtype: bytes or None
         """
         return self._rx.readline()
 

--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -48,8 +48,8 @@ import os
 import sys
 import microcontroller
 
-from ..core import Service
-from ...core.uuid import StandardUUID
+from .. import Service
+from ...uuid import StandardUUID
 from ...characteristics.string import FixedStringCharacteristic
 
 __version__ = "0.0.0-auto.0"

--- a/adafruit_ble/services/standard/hid.py
+++ b/adafruit_ble/services/standard/hid.py
@@ -33,6 +33,7 @@ import struct
 from micropython import const
 
 import _bleio
+from adafruit_ble.characteristics import Attribute
 from adafruit_ble.characteristics import Characteristic
 from adafruit_ble.characteristics.int import Uint8Characteristic
 from adafruit_ble.uuid import StandardUUID
@@ -77,8 +78,8 @@ class ReportIn:
         self._characteristic = _bleio.Characteristic.add_to_service(
             service.bleio_service,
             self.uuid.bleio_uuid,
-            properties=_bleio.Characteristic.READ | _bleio.Characteristic.NOTIFY,
-            read_perm=_bleio.Attribute.ENCRYPT_NO_MITM, write_perm=_bleio.Attribute.NO_ACCESS,
+            properties=Characteristic.READ | Characteristic.NOTIFY,
+            read_perm=Attribute.ENCRYPT_NO_MITM, write_perm=Attribute.NO_ACCESS,
             max_length=max_length, fixed_length=True)
         self._report_id = report_id
         self.usage_page = usage_page
@@ -86,7 +87,7 @@ class ReportIn:
 
         _bleio.Descriptor.add_to_characteristic(
             self._characteristic, _REPORT_REF_DESCR_UUID,
-            read_perm=_bleio.Attribute.ENCRYPT_NO_MITM, write_perm=_bleio.Attribute.NO_ACCESS,
+            read_perm=Attribute.ENCRYPT_NO_MITM, write_perm=Attribute.NO_ACCESS,
             initial_value=struct.pack('<BB', self._report_id, _REPORT_TYPE_INPUT))
 
     def send_report(self, report):
@@ -97,14 +98,14 @@ class ReportOut:
     """A single HID report that receives HID data from a client."""
     uuid = StandardUUID(0x24ad)
     def __init__(self, service, report_id, usage_page, usage, *, max_length):
-        self._characteristic = _bleio.Characteristic.add_to_service(
+        self._characteristic = Characteristic.add_to_service(
             service.bleio_service,
             self.uuid.bleio_uuid,
             max_length=max_length,
             fixed_length=True,
-            properties=(_bleio.Characteristic.READ | _bleio.Characteristic.WRITE |
-                        _bleio.Characteristic.WRITE_NO_RESPONSE),
-            read_perm=_bleio.Attribute.ENCRYPT_NO_MITM, write_perm=_bleio.Attribute.ENCRYPT_NO_MITM
+            properties=(Characteristic.READ | Characteristic.WRITE |
+                        Characteristic.WRITE_NO_RESPONSE),
+            read_perm=Attribute.ENCRYPT_NO_MITM, write_perm=Attribute.ENCRYPT_NO_MITM
         )
         self._report_id = report_id
         self.usage_page = usage_page
@@ -112,7 +113,7 @@ class ReportOut:
 
         _bleio.Descriptor.add_to_characteristic(
             self._characteristic, _REPORT_REF_DESCR_UUID,
-            read_perm=_bleio.Attribute.ENCRYPT_NO_MITM, write_perm=_bleio.Attribute.NO_ACCESS,
+            read_perm=Attribute.ENCRYPT_NO_MITM, write_perm=Attribute.NO_ACCESS,
             initial_value=struct.pack('<BB', self._report_id, _REPORT_TYPE_OUTPUT))
 
 _ITEM_TYPE_MAIN = const(0)
@@ -142,25 +143,25 @@ class HIDService(Service):
     default_field_name = "hid"
 
     boot_keyboard_in = Characteristic(uuid=StandardUUID(0x2A22),
-                                      properties=(_bleio.Characteristic.READ |
-                                                  _bleio.Characteristic.NOTIFY),
-                                      read_perm=_bleio.Attribute.ENCRYPT_NO_MITM,
-                                      write_perm=_bleio.Attribute.NO_ACCESS,
+                                      properties=(Characteristic.READ |
+                                                  Characteristic.NOTIFY),
+                                      read_perm=Attribute.ENCRYPT_NO_MITM,
+                                      write_perm=Attribute.NO_ACCESS,
                                       max_length=8, fixed_length=True)
 
     boot_keyboard_out = Characteristic(uuid=StandardUUID(0x2A32),
-                                       properties=(_bleio.Characteristic.READ |
-                                                   _bleio.Characteristic.WRITE |
-                                                   _bleio.Characteristic.WRITE_NO_RESPONSE),
-                                       read_perm=_bleio.Attribute.ENCRYPT_NO_MITM,
-                                       write_perm=_bleio.Attribute.ENCRYPT_NO_MITM,
+                                       properties=(Characteristic.READ |
+                                                   Characteristic.WRITE |
+                                                   Characteristic.WRITE_NO_RESPONSE),
+                                       read_perm=Attribute.ENCRYPT_NO_MITM,
+                                       write_perm=Attribute.ENCRYPT_NO_MITM,
                                        max_length=1, fixed_length=True)
 
     protocol_mode = Uint8Characteristic(uuid=StandardUUID(0x2A4E),
-                                        properties=(_bleio.Characteristic.READ |
-                                                    _bleio.Characteristic.WRITE_NO_RESPONSE),
-                                        read_perm=_bleio.Attribute.OPEN,
-                                        write_perm=_bleio.Attribute.OPEN,
+                                        properties=(Characteristic.READ |
+                                                    Characteristic.WRITE_NO_RESPONSE),
+                                        read_perm=Attribute.OPEN,
+                                        write_perm=Attribute.OPEN,
                                         initial_value=1, max_value=1)
     """Protocol mode: boot (0) or report (1)"""
 
@@ -169,24 +170,24 @@ class HIDService(Service):
     # bcd1.1, country = 0, flag = normal connect
     # TODO: Make this a struct.
     hid_information = Characteristic(uuid=StandardUUID(0x2A4A),
-                                     properties=_bleio.Characteristic.READ,
-                                     read_perm=_bleio.Attribute.ENCRYPT_NO_MITM,
-                                     write_perm=_bleio.Attribute.NO_ACCESS,
+                                     properties=Characteristic.READ,
+                                     read_perm=Attribute.ENCRYPT_NO_MITM,
+                                     write_perm=Attribute.NO_ACCESS,
                                      initial_value=b'\x01\x01\x00\x02')
     """Hid information including version, country code and flags."""
 
     report_map = Characteristic(uuid=StandardUUID(0x2A4B),
-                                properties=_bleio.Characteristic.READ,
-                                read_perm=_bleio.Attribute.ENCRYPT_NO_MITM,
-                                write_perm=_bleio.Attribute.NO_ACCESS,
+                                properties=Characteristic.READ,
+                                read_perm=Attribute.ENCRYPT_NO_MITM,
+                                write_perm=Attribute.NO_ACCESS,
                                 fixed_length=True)
     """This is the USB HID descriptor (not to be confused with a BLE Descriptor). It describes
        which report characteristic are what."""
 
     suspended = Uint8Characteristic(uuid=StandardUUID(0x2A4C),
-                                    properties=_bleio.Characteristic.WRITE_NO_RESPONSE,
-                                    read_perm=_bleio.Attribute.NO_ACCESS,
-                                    write_perm=_bleio.Attribute.ENCRYPT_NO_MITM,
+                                    properties=Characteristic.WRITE_NO_RESPONSE,
+                                    read_perm=Attribute.NO_ACCESS,
+                                    write_perm=Attribute.ENCRYPT_NO_MITM,
                                     max_value=1)
     """Controls whether the device should be suspended (0) or not (1)."""
 

--- a/adafruit_ble/services/standard/standard.py
+++ b/adafruit_ble/services/standard/standard.py
@@ -31,9 +31,9 @@ import time
 
 from .. import Service
 from ...uuid import StandardUUID
-from ..characteristics.string import StringCharacteristic
-from ..characteristics import StructCharacteristic
-from ..characteristics.int import Uint8Characteristic
+from ...characteristics.string import StringCharacteristic
+from ...characteristics import StructCharacteristic
+from ...characteristics.int import Uint8Characteristic
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"

--- a/adafruit_ble/services/standard/standard.py
+++ b/adafruit_ble/services/standard/standard.py
@@ -83,6 +83,6 @@ class CurrentTimeService(Service):
         """The current time as a `time.struct_time`. Day of year and whether DST is in effect
         are always -1.
         """
-        _, month, day, hour, minute, second, weekday, _, _ = self.current_time
+        year, month, day, hour, minute, second, weekday, _, _ = self.current_time
         # Bluetooth weekdays count from 1. struct_time counts from 0.
-        return time.struct_time((month, day, hour, minute, second, weekday - 1, -1))
+        return time.struct_time((year, month, day, hour, minute, second, weekday - 1, -1, -1))

--- a/adafruit_ble/services/standard/standard.py
+++ b/adafruit_ble/services/standard/standard.py
@@ -29,10 +29,10 @@ This module provides Service classes for BLE defined standard services.
 
 import time
 
-from ..core import Service
-from ...core.uuid import StandardUUID
+from .. import Service
+from ...uuid import StandardUUID
 from ..characteristics.string import StringCharacteristic
-from ..characteristics.core import StructCharacteristic
+from ..characteristics import StructCharacteristic
 from ..characteristics.int import Uint8Characteristic
 
 __version__ = "0.0.0-auto.0"

--- a/adafruit_ble/uuid/__init__.py
+++ b/adafruit_ble/uuid/__init__.py
@@ -56,7 +56,7 @@ class UUID:
         self.bleio_uuid.pack_into(buffer, offset=offset)
 
 class StandardUUID(UUID):
-    """Bluetooth defined, 16-bit UUID."""
+    """Standard 16-bit UUID defined by the Bluetooth SIG."""
     def __init__(self, uuid16):
         if not isinstance(uuid16, int):
             uuid16 = struct.unpack("<H", uuid16)[0]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,6 +8,7 @@
 
    top_level
    advertising
+   attributes
    characteristics
    services
    uuid

--- a/docs/attributes.rst
+++ b/docs/attributes.rst
@@ -1,0 +1,5 @@
+`adafruit_ble.attributes`
+====================================================
+
+.. automodule:: adafruit_ble.attributes
+   :members:

--- a/docs/bleio_mock.py
+++ b/docs/bleio_mock.py
@@ -1,13 +1,20 @@
 class Attribute:
-    OPEN = 0
     NO_ACCESS = 0
+    OPEN = 0
+    ENCRYPT_NO_MITM = 0
+    ENCRYPT_WITH_MITM = 0
+    LESC_ENCRYPT_WITH_MITM = 0
+    SIGNED_NO_MITM = 0
+    SIGNED_WITH_MITM = 0
 
 class UUID:
     def __init__(self, uuid):
         pass
 
 class Characteristic:
+    BROADCAST = 0
     READ = 0
     WRITE = 0
     NOTIFY = 0
+    INDICATE = 0
     WRITE_NO_RESPONSE = 0

--- a/docs/bleio_mock.py
+++ b/docs/bleio_mock.py
@@ -1,5 +1,6 @@
 class Attribute:
     OPEN = 0
+    NO_ACCESS = 0
 
 class UUID:
     def __init__(self, uuid):


### PR DESCRIPTION
I made a pass over all the files to do a more thorough code review, made some changes, and updated some doc. In general:

-- Use of `kwargs` was mostly dropped in favor of explicit arg names.
-- In a few places, the fact that an object was from `_bleio` was made more explicit.
-- Some pylint overrides were removed by renaming variables, etc.
-- A couple of pylint warnings were dealt with.
-- `_bleio.Attribute` and `_bleio.Characteristic` CONSTANT values were duplicated in the library, so that user code and library code does not need to refer to these directly.
-- 8, 16, and 32 bit signed and unsigned characteristic classes were created.
- Fixed an apparent bug in `time_struct` stuff, caught by @jerryneedell.

Tested `ble_uart_echo_test.py` and`ble_detailed_scan.py`.
Tested `ble_demo_central.py` and `ble_demo_periph.py` working together on a pair of CPB's.

There is one minor corresponding fix to circuitpython which I'll submit a PR for shortly.