### PR TITLE
Add an AdafruitRadio Advertisement class.

### DIFF
--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -69,11 +69,11 @@ class AdafruitRadio(Advertisement):
                          0x6,
                          _MANUFACTURING_DATA_ADT,
                          _ADAFRUIT_COMPANY_ID,
-                         struct.calcsize("<H24s"),
+                         struct.calcsize("<H248s"),
                          _RADIO_DATA_ID)
     manufacturer_data = LazyField(ManufacturerData,
                                   "manufacturer_data",
                                   advertising_data_type=_MANUFACTURING_DATA_ADT,
                                   company_id=_ADAFRUIT_COMPANY_ID,
                                   key_encoding="<H")
-    msg = ManufacturerDataField(_RADIO_DATA_ID, "<24s")  # 31 byte ads
+    msg = ManufacturerDataField(_RADIO_DATA_ID, "<248s")  # 255 byte ads

--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -43,6 +43,8 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 _MANUFACTURING_DATA_ADT = const(0xff)
 _ADAFRUIT_COMPANY_ID = const(0x0822)
 _COLOR_DATA_ID = const(0x0000)
+_RADIO_DATA_ID = const(0x0001)  # TODO: check this isn't already taken.
+
 
 class AdafruitColor(Advertisement):
     """Broadcast a single RGB color."""
@@ -61,12 +63,17 @@ class AdafruitColor(Advertisement):
     color = ManufacturerDataField(_COLOR_DATA_ID, "<I")
     """Color to broadcast as RGB integer."""
 
-# TODO: Add radio packets.
-#
-# class AdafruitRadio(Advertisement):
-#     prefix = b"\x06\xff\xff\xff\x00\x01"
-#
-#     channel = Struct()
-#     address =
-#     group =
-#     data =
+
+class AdafruitRadio(Advertisement):
+    prefix = struct.pack("<BBHBH",
+                         0x6,
+                         _MANUFACTURING_DATA_ADT,
+                         _ADAFRUIT_COMPANY_ID,
+                         struct.calcsize("<HI"),
+                         _RADIO_DATA_ID)
+    manufacturer_data = LazyField(ManufacturerData,
+                                  "manufacturer_data",
+                                  advertising_data_type=_MANUFACTURING_DATA_ADT,
+                                  company_id=_ADAFRUIT_COMPANY_ID,
+                                  key_encoding="<H")
+    msg = ManufacturerDataField(_RADIO_DATA_ID, "<24s")  # 31 byte ads

--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -65,11 +65,10 @@ class AdafruitColor(Advertisement):
 
 
 class AdafruitRadio(Advertisement):
-    prefix = struct.pack("<BBHBH",
+    prefix = struct.pack("<BBHH",
                          0x6,
                          _MANUFACTURING_DATA_ADT,
                          _ADAFRUIT_COMPANY_ID,
-                         struct.calcsize("<H248s"),
                          _RADIO_DATA_ID)
     manufacturer_data = LazyField(ManufacturerData,
                                   "manufacturer_data",

--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -65,6 +65,7 @@ class AdafruitColor(Advertisement):
 
 
 class AdafruitRadio(Advertisement):
+    """Broadcast arbitrary bytes as a radio message."""
     prefix = struct.pack("<BBHH",
                          0x6,
                          _MANUFACTURING_DATA_ADT,

--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -69,7 +69,7 @@ class AdafruitRadio(Advertisement):
                          0x6,
                          _MANUFACTURING_DATA_ADT,
                          _ADAFRUIT_COMPANY_ID,
-                         struct.calcsize("<HI"),
+                         struct.calcsize("<H24s"),
                          _RADIO_DATA_ID)
     manufacturer_data = LazyField(ManufacturerData,
                                   "manufacturer_data",


### PR DESCRIPTION
**DO NOT MERGE**

This doesn't work, in so far as I'm able to broadcast messages with the new class but incoming messages don't appear to match via the prefix. When I test-scan without any specified prefixes I see the receiving device registers these messages, but they're filtered out if the prefix is specified.

Any hints would be most welcome. I'm sure I'm missing something really *obvious* but just not seeing it. ;-)

My tactic has been to take the working example code and modify it only slightly. As you can see, even this minimal change hasn't worked. :-/