### PR TITLE
add BLERadio properties; add name and tx_power to advertisement scan_response

### DIFF
--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -254,7 +254,7 @@ class BLERadio:
 
     @property
     def name(self):
-        """The default name for this device. Used in advertisements and
+        """The name for this device. Used in advertisements and
         as the Device Name in the Generic Access Service, available to a connected peer.
         """
         return self._adapter.name

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -153,14 +153,16 @@ class BLERadio:
         Starts advertising the given advertisement.
 
         :param buf scan_response: scan response data packet bytes.
-            ``None`` if no scan response is needed.
+            If ``None``, a default scan response will be generated that includes
+            `BLERadio.name` and `BLERadio.tx_power`.
         :param float interval:  advertising interval, in seconds
         """
-        scan_response_data = None
-        if scan_response:
-            scan_response_data = bytes(scan_response)
+        if not scan_response:
+            scan_response = Advertisement()
+            scan_response.complete_name = self.name
+            scan_response.tx_power = self.tx_power
         self._adapter.start_advertising(bytes(advertisement),
-                                        scan_response=scan_response_data,
+                                        scan_response=bytes(scan_response),
                                         connectable=advertisement.connectable,
                                         interval=interval)
 
@@ -235,7 +237,7 @@ class BLERadio:
 
     @property
     def connected(self):
-        """True if any peers are connected to the adapter."""
+        """True if any peers are connected."""
         return self._adapter.connected
 
     @property
@@ -249,3 +251,28 @@ class BLERadio:
             wrapped_connections[i] = self._connection_cache[connection]
 
         return tuple(wrapped_connections)
+
+    @property
+    def name(self):
+        """The default name for this device. Used in advertisements and
+        as the Device Name in the Generic Access Service, available to a connected peer.
+        """
+        return self._adapter.name
+
+    @name.setter
+    def name(self, value):
+        self._adapter.name = value
+
+    @property
+    def tx_power(self):
+        """Transmit power, in dBm."""
+        return 0
+
+    @tx_power.setter
+    def tx_power(self, value):
+        raise NotImplementedError("setting tx_power not yet implemented")
+
+    @property
+    def address_bytes(self):
+        """The device address, as a ``bytes()`` object of length 6."""
+        return self._adapter.address.address_bytes

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -220,12 +220,7 @@ class Advertisement:
     # """Data size in a regular BLE packet."""
 
     def __init__(self):
-        """Create an advertising packet.
-
-        :param buf data: if not supplied (None), create an empty packet
-          if supplied, create a packet with supplied data. This is usually used
-          to parse an existing packet.
-        """
+        """Create an advertising packet."""
         self.data_dict = {}
         self.address = None
         self._rssi = None
@@ -248,8 +243,8 @@ class Advertisement:
 
     @property
     def rssi(self):
-        """Signal strength of the scanned advertisement. Only available on Advertisement's created
-           from ScanEntrys. (read-only)"""
+        """Signal strength of the scanned advertisement. Only available on Advertisements created
+           from ScanEntry objects. (read-only)"""
         return self._rssi
 
     @classmethod

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -243,8 +243,8 @@ class Advertisement:
 
     @property
     def rssi(self):
-        """Signal strength of the scanned advertisement. Only available on Advertisements created
-           from ScanEntry objects. (read-only)"""
+        """Signal strength of the scanned advertisement. Only available on Advertisements returned
+           from `BLERadio.start_scan()`. (read-only)"""
         return self._rssi
 
     @classmethod


### PR DESCRIPTION
Fixes #35 and #36.

- Add `BLERadio.name`, which sets and gets `_bleio.Adapter.name`
- Add `BLERadio.tx_power`, which now is just 0. Setting is not yet implemented (need an `Adapter` API).
- Add `BLERadio.address_bytes`, which gets `_bleio.Adapter.address.address_bytes`. I didn't want to expose or wrap `_bleio.Address`, and getting the bytes is the main use case.
- If no `scan_response` is supplied to `BLERadio.start_advertising()`, a default scan response is generated, which contains `.name` as the COMPLETE_NAME, and `.tx_power`.

Originally I added an optional argument to `.start_advertising()` to specify the name. But that doesn't set the name used in the Generic Information Service, and the Bluefruit LE app uses that GIS name in preference to the advertising name, which is confusing. Presumably other apps do this too. So it's good to make the advertising name and the GIS name the same. So the way to use this is:
```python
ble = BLERadio()
ble.name = 'PreferredName'
# ...
ble.start_advertising()
```