### PR TITLE
Fix bug where if category is out of bounds it was crashing

### DIFF
--- a/adafruit_ble/services/apple.py
+++ b/adafruit_ble/services/apple.py
@@ -165,6 +165,8 @@ class Notification:
         category = None
         if self.category_id < len(NOTIFICATION_CATEGORIES):
             category = NOTIFICATION_CATEGORIES[self.category_id]
+        else:
+            category = "Reserved"
 
         if self.silent:
             flags.append("silent")


### PR DESCRIPTION
John had a crash with this error:
```
Traceback (most recent call last):
  File "code.py", line 176, in <module>
  File "code.py", line 152, in <module>
  File "/lib/adafruit_ble/services/apple.py", line 154, in __str__
TypeError: can't convert 'NoneType' object to str implicitly
```
I know, old version. However, there was still the possible condition to cause this. According to https://developer.apple.com/library/archive/documentation/CoreBluetooth/Reference/AppleNotificationCenterServiceSpecification/Appendix/Appendix.html, it should be marked Reserved, so I just made the string be reserved.