### PR TITLE
Added pylint ignores so Actions will pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - pip install --force-reinstall "pylint<3"
 
 script:
-- pylint --disable=too-few-public-methods adafruit_ble/**/*.py adafruit_ble/*.py
+- pylint adafruit_ble/**/*.py adafruit_ble/*.py
 - ([[ ! -d "examples" ]] || pylint --disable=missing-docstring,invalid-name,bad-whitespace
   examples/*.py)
 - circuitpython-build-bundles --filename_prefix adafruit-circuitpython-ble

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -85,6 +85,8 @@ def encode_data(data_dict, *, key_encoding="B"):
 
 class AdvertisingDataField:
     """Top level class for any descriptor classes that live in Advertisement or its subclasses."""
+    # pylint: disable=too-few-public-methods
+    pass
 
 class AdvertisingFlag:
     """A single bit flag within an AdvertisingFlags object."""

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -85,7 +85,8 @@ def encode_data(data_dict, *, key_encoding="B"):
 
 class AdvertisingDataField:
     """Top level class for any descriptor classes that live in Advertisement or its subclasses."""
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-few-public-methods,unnecessary-pass
+    pass
 
 class AdvertisingFlag:
     """A single bit flag within an AdvertisingFlags object."""

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -86,7 +86,6 @@ def encode_data(data_dict, *, key_encoding="B"):
 class AdvertisingDataField:
     """Top level class for any descriptor classes that live in Advertisement or its subclasses."""
     # pylint: disable=too-few-public-methods
-    pass
 
 class AdvertisingFlag:
     """A single bit flag within an AdvertisingFlags object."""

--- a/adafruit_ble/attributes/__init__.py
+++ b/adafruit_ble/attributes/__init__.py
@@ -63,6 +63,7 @@ class Attribute:
 
          security_mode: authenticated data signing, without man-in-the-middle protection
 """
+    # pylint: disable=too-few-public-methods
     NO_ACCESS = _bleio.Attribute.NO_ACCESS
     OPEN = _bleio.Attribute.OPEN
     ENCRYPT_NO_MITM = _bleio.Attribute.ENCRYPT_NO_MITM

--- a/adafruit_ble/characteristics/int.py
+++ b/adafruit_ble/characteristics/int.py
@@ -60,30 +60,36 @@ class IntCharacteristic(StructCharacteristic):
 
 class Int8Characteristic(IntCharacteristic):
     """Int8 number."""
+    # pylint: disable=too-few-public-methods
     def __init__(self, *, min_value=-128, max_value=127, **kwargs):
         super().__init__("<b", min_value, max_value, **kwargs)
 
 class Uint8Characteristic(IntCharacteristic):
     """Uint8 number."""
+    # pylint: disable=too-few-public-methods
     def __init__(self, *, min_value=0, max_value=0xff, **kwargs):
         super().__init__("<B", min_value, max_value, **kwargs)
 
 class Int16Characteristic(IntCharacteristic):
     """Int16 number."""
+    # pylint: disable=too-few-public-methods
     def __init__(self, *, min_value=-32768, max_value=32767, **kwargs):
         super().__init__("<h", min_value, max_value, **kwargs)
 
 class Uint16Characteristic(IntCharacteristic):
     """Uint16 number."""
+    # pylint: disable=too-few-public-methods
     def __init__(self, *, min_value=0, max_value=0xffff, **kwargs):
         super().__init__("<H", min_value, max_value, **kwargs)
 
 class Int32Characteristic(IntCharacteristic):
     """Int32 number."""
+    # pylint: disable=too-few-public-methods
     def __init__(self, *, min_value=-2147483648, max_value=2147483647, **kwargs):
         super().__init__("<i", min_value, max_value, **kwargs)
 
 class Uint32Characteristic(IntCharacteristic):
     """Uint32 number."""
+    # pylint: disable=too-few-public-methods
     def __init__(self, *, min_value=0, max_value=0xffffffff, **kwargs):
         super().__init__("<I", min_value, max_value, **kwargs)

--- a/adafruit_ble/services/midi.py
+++ b/adafruit_ble/services/midi.py
@@ -36,6 +36,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 class MidiIOCharacteristic(Characteristic):
     """Workhorse MIDI Characteristic that carries midi messages both directions. Unimplemented."""
+    # pylint: disable=too-few-public-methods
     uuid = VendorUUID("7772E5DB-3868-4112-A1A9-F2669D106BF3")
     def __init__(self, **kwargs):
         super().__init__(properties=(Characteristic.NOTIFY |

--- a/adafruit_ble/services/standard/__init__.py
+++ b/adafruit_ble/services/standard/__init__.py
@@ -38,6 +38,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 class AppearanceCharacteristic(StructCharacteristic):
     """What type of device it is"""
+    # pylint: disable=too-few-public-methods
     uuid = StandardUUID(0x2a01)
 
     def __init__(self, **kwargs):

--- a/adafruit_ble/services/standard/hid.py
+++ b/adafruit_ble/services/standard/hid.py
@@ -96,6 +96,7 @@ class ReportIn:
 
 class ReportOut:
     """A single HID report that receives HID data from a client."""
+    # pylint: disable=too-few-public-methods
     uuid = StandardUUID(_REPORT_UUID_NUM)
     def __init__(self, service, report_id, usage_page, usage, *, max_length):
         self._characteristic = _bleio.Characteristic.add_to_service(
@@ -248,6 +249,7 @@ class HIDService(Service):
             i += size
 
         def get_report_info(collection, reports):
+            """ Gets info about hid reports """
             for main in collection["mains"]:
                 if "type" in main:
                     get_report_info(main, reports)
@@ -269,7 +271,7 @@ class HIDService(Service):
             reports = {}
             get_report_info(collection, reports)
             if len(reports) > 1:
-                raise NotImplementedError("Only on report id per Application collection supported")
+                raise NotImplementedError("Only one report id per Application collection supported")
 
             report_id, report = list(reports.items())[0]
             output_size = report["output_size"]


### PR DESCRIPTION
There were 2 things I wasn't quite sure about:

line 86 of adafruit_ble/advertising/\_\_init\_\_.py
I added a pass to it because It wouldn't pass pylint completely empty even with an ignore. I don't think this should have an effect on the operation of the module, but I just wanted to check.

Edit: So I'm realizing that adding a pass causes travis to fail, but in testing it locally using the linting command from build.yml, that was the only way it would pass

line 252 of adafruit\_ble/services/hid.py
It didn't have a docstring so I added one. Just wanted to see if there was a better way of describing that function than what I put