### PR TITLE
Add explicit inclusion of adafruit_ble to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,5 @@ setup(
     # What does your project relate to?
     keywords='adafruit blinka circuitpython micropython ble bluetooth',
 
-    packages=find_packages(include=["adafruit_ble.*"]),
+    packages=find_packages(include=["adafruit_ble", "adafruit_ble.*"]),
 )


### PR DESCRIPTION
Hopefully this will make BLERadio available on Raspberry Pi (but it will fail on the `_bleio` stub).