### PR TITLE
check initial_value is explicitly None

### DIFF
--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -239,7 +239,7 @@ class StructCharacteristic(Characteristic):
     ):
         self._struct_format = struct_format
         self._expected_size = struct.calcsize(struct_format)
-        if initial_value:
+        if initial_value is not None:
             initial_value = struct.pack(self._struct_format, *initial_value)
         super().__init__(
             uuid=uuid,

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -46,7 +46,7 @@ class FloatCharacteristic(StructCharacteristic):
         write_perm=Attribute.OPEN,
         initial_value=None
     ):
-        if initial_value:
+        if initial_value is not None:
             initial_value = (initial_value,)
         super().__init__(
             "<f",

--- a/adafruit_ble/characteristics/int.py
+++ b/adafruit_ble/characteristics/int.py
@@ -51,7 +51,7 @@ class IntCharacteristic(StructCharacteristic):
     ):
         self._min_value = min_value
         self._max_value = max_value
-        if initial_value:
+        if initial_value is not None:
             if not self._min_value <= initial_value <= self._max_value:
                 raise ValueError("initial_value out of range")
             initial_value = (initial_value,)


### PR DESCRIPTION
`IntCharacteristic`, `FloatCharacteristic`, and `StructCharacteristic` were not checking that `initial_value` was explicitly `None`, but just that it was false-y. This made it not possible to give an initial value of `0`, `0.0`, or `b''`, respectively (though I think `b''` is a bad value, but now that will be caught).