### PR TITLE
512 is max length for variable length Characteristics, not fixed

### DIFF
--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -86,7 +86,7 @@ def encode_data(data_dict, *, key_encoding="B"):
         struct.pack_into(key_encoding, data, i + 1, key)
         data[i + 1 + key_size : i + 1 + item_length] = bytes(value)
         i += 1 + item_length
-    return data
+    return bytes(data)
 
 
 class AdvertisingDataField:

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -51,7 +51,8 @@ class Characteristic:
     :param int write_perm: Specifies whether the characteristic can be written by a client,
        and if so, which security mode is required. Values allowed are the same as ``read_perm``.
     :param int max_length: Maximum length in bytes of the characteristic value. The maximum allowed
-       is 512, or on nRF, 510 if ``fixed_length`` is True. The default, 20, is the maximum
+       by the BLE specification is 512. On nRF, if ``fixed_length`` is ``True``, the maximum
+       is 510. The default value is 20, which is the maximum
        number of data bytes that fit in a single BLE 4.x ATT packet.
     :param bool fixed_length: True if the characteristic value is of fixed length.
     :param buf initial_value: The initial value for this characteristic. If not given, will be

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -51,7 +51,7 @@ class Characteristic:
     :param int write_perm: Specifies whether the characteristic can be written by a client,
        and if so, which security mode is required. Values allowed are the same as ``read_perm``.
     :param int max_length: Maximum length in bytes of the characteristic value. The maximum allowed
-       is 512, or possibly 510 if ``fixed_length`` is False. The default, 20, is the maximum
+       is 512, or on nRF, 510 if ``fixed_length`` is True. The default, 20, is the maximum
        number of data bytes that fit in a single BLE 4.x ATT packet.
     :param bool fixed_length: True if the characteristic value is of fixed length.
     :param buf initial_value: The initial value for this characteristic. If not given, will be

--- a/adafruit_ble/characteristics/string.py
+++ b/adafruit_ble/characteristics/string.py
@@ -51,7 +51,7 @@ class StringCharacteristic(Characteristic):
             properties=properties,
             read_perm=read_perm,
             write_perm=write_perm,
-            max_length=510,  # shorter than 512 due to fixed_length==False
+            max_length=512,
             fixed_length=False,
             initial_value=initial_value,
         )


### PR DESCRIPTION
I got this backwards initially:
variable-length characteristics can have up to 512 bytes of data.
Fixed length can have up to 510 bytes, on nRF.
See https://devzone.nordicsemi.com/f/nordic-q-a/12823/maximum-fixed-length-attribute-length-vs-maximum-variable-length-attribute-length.