### PR TITLE
Easier specification of prefixes; fixes for use with bleak

### DIFF
--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -261,7 +261,7 @@ class BLERadio:
            once empty."""
         self._adapter.stop_scan()
 
-    def connect(self, advertisement, *, timeout=4):
+    def connect(self, advertisement, *, timeout=10.0):
         """
         Initiates a `BLEConnection` to the peer that advertised the given advertisement.
 

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -231,7 +231,7 @@ class BLERadio:
         """
         if not advertisement_types:
             advertisement_types = (Advertisement,)
-        prefixes = b"".join(adv.prefix for adv in advertisement_types)
+        prefixes = b"".join(adv.get_prefix_bytes() for adv in advertisement_types)
         for entry in self._adapter.start_scan(
             prefixes=prefixes,
             buffer_size=buffer_size,

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -261,7 +261,7 @@ class BLERadio:
            once empty."""
         self._adapter.stop_scan()
 
-    def connect(self, advertisement, *, timeout=10.0):
+    def connect(self, advertisement, *, timeout=4.0):
         """
         Initiates a `BLEConnection` to the peer that advertised the given advertisement.
 

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -103,6 +103,8 @@ class AdvertisingFlag:
         self._bitmask = 1 << bit_position
 
     def __get__(self, obj, cls):
+        if obj is None:
+            return self
         return (obj.flags & self._bitmask) != 0
 
     def __set__(self, obj, value):

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -290,6 +290,8 @@ class Advertisement:
         """Return a merged version of match_prefixes as a single bytes object,
         with length headers.
         """
+        # Check for deprecated `prefix` class attribute.
+        cls._prefix_bytes = getattr(cls, "prefix", None)
         # Do merge once and memoize it.
         if cls._prefix_bytes is None:
             cls._prefix_bytes = (

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -304,7 +304,15 @@ class Advertisement:
         return cls._prefix_bytes
 
     @classmethod
-    def matches(cls, entry, all_=True):
+    def matches(cls, entry):
+        """Returns ``True`` if the given `_bleio.ScanEntry` advertisement fields
+        matches all of the given prefixes in the `match_prefixes` tuple attribute.
+        Subclasses may override this to match any instead of all.
+        """
+        return cls.matches_prefixes(entry, all_=True)
+
+    @classmethod
+    def matches_prefixes(cls, entry, *, all_):
         """Returns ``True`` if the given `_bleio.ScanEntry` advertisement fields
         match any or all of the given prefixes in the `match_prefixes` tuple attribute.
         If `all_` is ``True``, all the prefixes must match. If ``all_`` is ``False``,

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -315,7 +315,7 @@ class Advertisement:
     def matches_prefixes(cls, entry, *, all_):
         """Returns ``True`` if the given `_bleio.ScanEntry` advertisement fields
         match any or all of the given prefixes in the `match_prefixes` tuple attribute.
-        If `all_` is ``True``, all the prefixes must match. If ``all_`` is ``False``,
+        If ``all_`` is ``True``, all the prefixes must match. If ``all_`` is ``False``,
         returns ``True`` if at least one of the prefixes match.
         """
         # Returns True if cls.get_prefix_bytes() is empty.

--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -48,14 +48,15 @@ _COLOR_DATA_ID = const(0x0000)
 class AdafruitColor(Advertisement):
     """Broadcast a single RGB color."""
 
-    # This prefix matches all
-    prefix = struct.pack(
-        "<BBHBH",
-        0x6,
-        _MANUFACTURING_DATA_ADT,
-        _ADAFRUIT_COMPANY_ID,
-        struct.calcsize("<HI"),
-        _COLOR_DATA_ID,
+    # This single prefix matches all color advertisements.
+    match_prefixes = (
+        struct.pack(
+            "<BHBH",
+            _MANUFACTURING_DATA_ADT,
+            _ADAFRUIT_COMPANY_ID,
+            struct.calcsize("<HI"),
+            _COLOR_DATA_ID,
+        ),
     )
     manufacturer_data = LazyObjectField(
         ManufacturerData,

--- a/adafruit_ble/advertising/apple.py
+++ b/adafruit_ble/advertising/apple.py
@@ -1,5 +1,6 @@
 # class iBeacon(Advertisement):
-#     prefix = b"\xff\x00\x4c\x02" # Apple manufacturer data with subtype 2
+#     # Apple manufacturer data with subtype 2
+#     match_prefixes = (b"\xff\x00\x4c\x02",)
 #
 #     proximity_uuid =
 #     major =

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -135,7 +135,7 @@ class BoundServiceList:
             data.append(str(service_uuid))
         for service_uuid in self._vendor_services:
             data.append(str(service_uuid))
-        return " ".join(data)
+        return "<BoundServiceList: {}>".format(", ".join(data))
 
 
 class ServiceList(AdvertisingDataField):
@@ -156,7 +156,7 @@ class ServiceList(AdvertisingDataField):
 
     def __get__(self, obj, cls):
         if not self._present(obj) and not obj.mutable:
-            return None
+            return ()
         if not hasattr(obj, "adv_service_lists"):
             obj.adv_service_lists = {}
         first_adt = self.standard_services[0]
@@ -168,8 +168,8 @@ class ServiceList(AdvertisingDataField):
 class ProvideServicesAdvertisement(Advertisement):
     """Advertise what services that the device makes available upon connection."""
 
-    # This is four prefixes, one for each ADT that can carry service UUIDs.
-    prefix = b"\x01\x02\x01\x03\x01\x06\x01\x07"
+    # Prefixes that match each ADT that can carry service UUIDs.
+    match_prefixes = (b"\x02", b"\x03", b"\x06", b"\x07")
     services = ServiceList(standard_services=[0x02, 0x03], vendor_services=[0x06, 0x07])
     """List of services the device can provide."""
 
@@ -182,15 +182,15 @@ class ProvideServicesAdvertisement(Advertisement):
         self.flags.le_only = True
 
     @classmethod
-    def matches(cls, entry):
-        return entry.matches(cls.prefix, all=False)
+    def matches(cls, entry, all_=False):
+        return super().matches(entry, all_=all_)
 
 
 class SolicitServicesAdvertisement(Advertisement):
     """Advertise what services the device would like to use over a connection."""
 
-    # This is two prefixes, one for each ADT that can carry solicited service UUIDs.
-    prefix = b"\x01\x14\x01\x15"
+    # Prefixes that match each ADT that can carry solicited service UUIDs.
+    match_prefixes = (b"\x14", b"\x15")
 
     solicited_services = ServiceList(standard_services=[0x14], vendor_services=[0x15])
     """List of services the device would like to use."""

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -155,6 +155,8 @@ class ServiceList(AdvertisingDataField):
         return False
 
     def __get__(self, obj, cls):
+        if obj is None:
+            return self
         if not self._present(obj) and not obj.mutable:
             return ()
         if not hasattr(obj, "adv_service_lists"):
@@ -315,6 +317,8 @@ class ServiceData(AdvertisingDataField):
         self._prefix = bytes(service.uuid)
 
     def __get__(self, obj, cls):
+        if obj is None:
+            return self
         # If not present at all and mutable, then we init it, otherwise None.
         if self._adt not in obj.data_dict:
             if obj.mutable:

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -184,8 +184,11 @@ class ProvideServicesAdvertisement(Advertisement):
         self.flags.le_only = True
 
     @classmethod
-    def matches(cls, entry, all_=False):
-        return super().matches(entry, all_=all_)
+    def matches(cls, entry):
+        """Only one kind of service list need be present in a ProvideServicesAdvertisement,
+        so override the default behavior and match any prefix, not all.
+        """
+        return cls.matches_prefixes(entry, all_=False)
 
 
 class SolicitServicesAdvertisement(Advertisement):

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -319,7 +319,9 @@ class ServiceData(AdvertisingDataField):
             self._adt = 0x21
         self._prefix = bytes(service.uuid)
 
-    def __get__(self, obj, cls):
+    def __get__(
+        self, obj, cls
+    ):  # pylint: disable=too-many-return-statements,too-many-branches
         if obj is None:
             return self
         # If not present at all and mutable, then we init it, otherwise None.

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -151,6 +151,10 @@ class Characteristic:
         )
 
     def __get__(self, service, cls=None):
+        # CircuitPython doesn't invoke descriptor protocol on obj's class,
+        # but CPython does. In the CPython case, pretend that it doesn't.
+        if service is None:
+            return self
         self._ensure_bound(service)
         bleio_characteristic = service.bleio_characteristics[self.field_name]
         return bleio_characteristic.value
@@ -210,6 +214,8 @@ class ComplexCharacteristic:
         )
 
     def __get__(self, service, cls=None):
+        if service is None:
+            return self
         bound_object = self.bind(service)
         setattr(service, self.field_name, bound_object)
         return bound_object
@@ -253,6 +259,8 @@ class StructCharacteristic(Characteristic):
         )
 
     def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
         raw_data = super().__get__(obj, cls)
         if len(raw_data) < self._expected_size:
             return None

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -58,6 +58,8 @@ class FloatCharacteristic(StructCharacteristic):
         )
 
     def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
         return super().__get__(obj)[0]
 
     def __set__(self, obj, value):

--- a/adafruit_ble/characteristics/int.py
+++ b/adafruit_ble/characteristics/int.py
@@ -66,6 +66,8 @@ class IntCharacteristic(StructCharacteristic):
         )
 
     def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
         return super().__get__(obj)[0]
 
     def __set__(self, obj, value):

--- a/adafruit_ble/characteristics/string.py
+++ b/adafruit_ble/characteristics/string.py
@@ -57,6 +57,8 @@ class StringCharacteristic(Characteristic):
         )
 
     def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
         return str(super().__get__(obj, cls), "utf-8")
 
     def __set__(self, obj, value):
@@ -76,4 +78,6 @@ class FixedStringCharacteristic(Characteristic):
         )
 
     def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
         return str(super().__get__(obj, cls), "utf-8")

--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -66,6 +66,7 @@ class DeviceInfoService(Service):
             if serial_number is None:
                 try:
                     import microcontroller
+
                     serial_number = binascii.hexlify(
                         microcontroller.cpu.uid  # pylint: disable=no-member
                     ).decode("utf-8")

--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -73,10 +73,7 @@ class DeviceInfoService(Service):
                 except ImportError:
                     pass
             if firmware_revision is None:
-                try:
-                    firmware_revision = os.uname().version
-                except AttributeError:
-                    pass
+                firmware_revision = getattr(os.uname(), "version", None)
         super().__init__(
             manufacturer=manufacturer,
             software_revision=software_revision,

--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -65,7 +65,7 @@ class DeviceInfoService(Service):
                 model_number = sys.platform
             if serial_number is None:
                 try:
-                    import microcontroller
+                    import microcontroller  # pylint: disable=import-outside-toplevel
 
                     serial_number = binascii.hexlify(
                         microcontroller.cpu.uid  # pylint: disable=no-member

--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -29,7 +29,6 @@
 import binascii
 import os
 import sys
-import microcontroller
 
 from .. import Service
 from ...uuid import StandardUUID
@@ -65,11 +64,18 @@ class DeviceInfoService(Service):
             if model_number is None:
                 model_number = sys.platform
             if serial_number is None:
-                serial_number = binascii.hexlify(
-                    microcontroller.cpu.uid  # pylint: disable=no-member
-                ).decode("utf-8")
+                try:
+                    import microcontroller
+                    serial_number = binascii.hexlify(
+                        microcontroller.cpu.uid  # pylint: disable=no-member
+                    ).decode("utf-8")
+                except ImportError:
+                    pass
             if firmware_revision is None:
-                firmware_revision = os.uname().version
+                try:
+                    firmware_revision = os.uname().version
+                except AttributeError:
+                    pass
         super().__init__(
             manufacturer=manufacturer,
             software_revision=software_revision,

--- a/adafruit_ble/services/standard/hid.py
+++ b/adafruit_ble/services/standard/hid.py
@@ -30,8 +30,8 @@ BLE Human Interface Device (HID)
 """
 import struct
 
-import _bleio
 from micropython import const
+import _bleio
 
 from adafruit_ble.characteristics import Attribute
 from adafruit_ble.characteristics import Characteristic


### PR DESCRIPTION
- Advertisement-matching prefixes are now specified as tuples of prefixes. You no longer need to count up the bytes and include a length byte in front of each subprefix. The class attribute has been renamed from `prefix` to `match_prefixes`. _This is an incompatible change_; a few other libraries will need to change also. PR's will be opened for those libraries.
- All the definitions of `__get__(self, obj, cls)` now check for `obj is None`, and return `self` in that case. This is because MicroPython/CircuitPython don't invoke descriptor protocol on `obj`'s class, but CPython does. So to be uniform, when running in CPython, check for this case and just return the actual object.
- Catch when `microcontroller` is not present, such as when running in CPython.
- Windows doesn't have `os.uname()`, so catch that.
- Make it easier and clearer for an `Advertisement` subclass to change the behavior of `matches()` from `all` to `any`, by providing a `match_prefixes(cls, entry, all_=True)` class method to call. Note that the arg is called `all_`, because it otherwise conflicts with the builtin function `all()`. See https://github.com/adafruit/circuitpython/issues/3007 for a related issue.
- Improve printed representation of some classes.

Fixes #82.

