### PR TITLE
Fix color picker example for animation

### DIFF
--- a/examples/ble_bluefruit_color_picker.py
+++ b/examples/ble_bluefruit_color_picker.py
@@ -9,8 +9,8 @@ from adafruit_bluefruit_connect.packet import Packet
 from adafruit_bluefruit_connect.color_packet import ColorPacket
 
 ble = BLERadio()
-uart_server = UARTService()
-advertisement = ProvideServicesAdvertisement(uart_server)
+uart_service = UARTService()
+advertisement = ProvideServicesAdvertisement(uart_service)
 
 pixels = neopixel.NeoPixel(board.NEOPIXEL, 10, brightness=0.1)
 
@@ -22,7 +22,7 @@ while True:
     ble.stop_advertising()
 
     while ble.connected:
-        packet = Packet.from_stream(uart_server)
+        packet = Packet.from_stream(uart_service)
         if isinstance(packet, ColorPacket):
             print(packet.color)
             pixels.fill(packet.color)

--- a/examples/ble_bluefruit_color_picker.py
+++ b/examples/ble_bluefruit_color_picker.py
@@ -22,7 +22,8 @@ while True:
     ble.stop_advertising()
 
     while ble.connected:
-        packet = Packet.from_stream(uart_service)
-        if isinstance(packet, ColorPacket):
-            print(packet.color)
-            pixels.fill(packet.color)
+        if uart_service.in_waiting:
+            packet = Packet.from_stream(uart_service)
+            if isinstance(packet, ColorPacket):
+                print(packet.color)
+                pixels.fill(packet.color)


### PR DESCRIPTION
The current color picker example is problematic when displaying animations on the pixel strip.

As soon as the app connects to the device, the animation crawls to a haul.

Checking if the UARTService is in waiting before attempting to read from the stream fixes this issue.

Also renamed `uart_service` to `uart_server` for consistency.

Examples below.

1. Running the code below will display the animation normally until the app connects. Once the app is connected to the device, the animation slows down.

```python
# CircuitPython NeoPixel Color Picker Example
# Animation slows down when device is connected to from app

import board
import neopixel
from adafruit_ble import BLERadio
from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
from adafruit_ble.services.nordic import UARTService
from adafruit_bluefruit_connect.packet import Packet
from adafruit_bluefruit_connect.color_packet import ColorPacket

from adafruit_led_animation.animation.blink import Blink
from adafruit_led_animation.color import RED

ble = BLERadio()
uart_service = UARTService()
advertisement = ProvideServicesAdvertisement(uart_service)

pixels = neopixel.NeoPixel(board.D12, 5, brightness=0.1)
blink = Blink(pixels, speed=0.5, color=RED)

while True:
    # Advertise when not connected.
    ble.start_advertising(advertisement)
    while not ble.connected:
        blink.animate()
    ble.stop_advertising()

    while ble.connected:
        blink.animate()
        packet = Packet.from_stream(uart_service)
        if isinstance(packet, ColorPacket):
            print(packet.color)
            blink = Blink(pixels, speed=0.5, color=packet.color)
```
2. This behavior is fixed when checking for `uart_service.in_waiting` like in the updated example.

```python
# CircuitPython NeoPixel Color Picker Example
# Animation doesn't slow down when bluetooth connected

import board
import neopixel
from adafruit_ble import BLERadio
from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
from adafruit_ble.services.nordic import UARTService
from adafruit_bluefruit_connect.packet import Packet
from adafruit_bluefruit_connect.color_packet import ColorPacket

from adafruit_led_animation.animation.blink import Blink
from adafruit_led_animation.color import RED

ble = BLERadio()
uart_service = UARTService()
advertisement = ProvideServicesAdvertisement(uart_service)

pixels = neopixel.NeoPixel(board.D12, 5, brightness=0.1)
blink = Blink(pixels, speed=0.5, color=RED)

while True:
    # Advertise when not connected.
    ble.start_advertising(advertisement)
    while not ble.connected:
        blink.animate()
    ble.stop_advertising()

    while ble.connected:
        blink.animate()
        if uart_service.in_waiting:
            packet = Packet.from_stream(uart_service)
            if isinstance(packet, ColorPacket):
                print(packet.color)
                blink = Blink(pixels, speed=0.5, color=packet.color)

```
