### PR TITLE
fix scan filtering for cases like (Advertisement, SubclassOfAdvertisment)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Versions
       run: |
         python3 --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
         awk -F '\/' '{ print tolower($2) }' |
         tr '_' '-'
         )
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Versions
       run: |
         python3 --version

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -231,7 +231,13 @@ class BLERadio:
         """
         if not advertisement_types:
             advertisement_types = (Advertisement,)
-        prefixes = b"".join(adv.get_prefix_bytes() for adv in advertisement_types)
+
+        all_prefix_bytes = tuple(adv.get_prefix_bytes() for adv in advertisement_types)
+
+        # If one of the advertisement_types has no prefix restrictions, then
+        # no prefixes should be specified at all, so we match everything.
+        prefixes = b"" if b"" in all_prefix_bytes else b"".join(all_prefix_bytes)
+
         for entry in self._adapter.start_scan(
             prefixes=prefixes,
             buffer_size=buffer_size,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-autodoc_mock_imports = ["board", "microcontroller"]
+autodoc_mock_imports = ["bleak", "board", "microcontroller"]
 autodoc_member_order = "bysource"
 add_module_names = False
 


### PR DESCRIPTION
Fixes #92.

start_scan() did not handle the case of mixing an `Advertisement` class with no prefixes with classes with some prefixes. This is used in `examples/ble_detailed_scan.py`.

Thanks to anecdata (in discord) for spotting this problem.