### PR TITLE
Add READ & NOTIFY Permissions to Battery Service

### DIFF
--- a/adafruit_ble/services/standard/__init__.py
+++ b/adafruit_ble/services/standard/__init__.py
@@ -70,8 +70,11 @@ class BatteryService(Service):
     """Provides battery level information"""
 
     uuid = StandardUUID(0x180F)
-    level = Uint8Characteristic(max_value=100, properties=Characteristic.READ | Characteristic.NOTIFY, uuid=StandardUUID(0x2A19))
-
+    level = Uint8Characteristic(
+        max_value=100,
+        properties=Characteristic.READ | Characteristic.NOTIFY,
+        uuid=StandardUUID(0x2A19),
+    )
 
 class CurrentTimeService(Service):
     """Provides the current time."""

--- a/adafruit_ble/services/standard/__init__.py
+++ b/adafruit_ble/services/standard/__init__.py
@@ -29,6 +29,7 @@ import time
 
 from .. import Service
 from ...uuid import StandardUUID
+from ...characteristics import Characteristic
 from ...characteristics.string import StringCharacteristic
 from ...characteristics import StructCharacteristic
 from ...characteristics.int import Uint8Characteristic
@@ -69,7 +70,7 @@ class BatteryService(Service):
     """Provides battery level information"""
 
     uuid = StandardUUID(0x180F)
-    level = Uint8Characteristic(max_value=100, uuid=StandardUUID(0x2A19))
+    level = Uint8Characteristic(max_value=100, properties=Characteristic.READ | Characteristic.NOTIFY, uuid=StandardUUID(0x2A19))
 
 
 class CurrentTimeService(Service):

--- a/adafruit_ble/services/standard/__init__.py
+++ b/adafruit_ble/services/standard/__init__.py
@@ -76,6 +76,7 @@ class BatteryService(Service):
         uuid=StandardUUID(0x2A19),
     )
 
+
 class CurrentTimeService(Service):
     """Provides the current time."""
 


### PR DESCRIPTION
This change allowed me to be able to read the battery service characteristic from nRF Connect as well as a forked version of GadgetBridge.  The unmodified code has properties equal to 0 for this service.   Reference this forum post: https://forums.adafruit.com/viewtopic.php?f=60&t=167056.