### PR TITLE
Set up an on-board HCI adapter automatically

### DIFF
--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -158,6 +158,12 @@ class BLERadio:
     def __init__(self, adapter=None):
         if not adapter:
             adapter = _bleio.adapter
+            if hasattr(adapter, "hci_uart_init"):
+                # Set up an onboard HCI BLE adapter
+                from adafruit_ble import hci  # pylint: disable=import-outside-toplevel
+
+                hci.init()
+
         self._adapter = adapter
         self._current_advertisement = None
         self._connection_cache = {}

--- a/adafruit_ble/hci.py
+++ b/adafruit_ble/hci.py
@@ -44,6 +44,7 @@ def esp32_hci_init(
 ):
     """Do ESP32-specific HCI adapter initialization."""
 
+    # pylint: disable=too-many-locals
     reset = digitalio.DigitalInOut(esp_reset)
     reset.switch_to_output(not reset_high)
 
@@ -83,8 +84,8 @@ def esp32_hci_init(
     if debug:
         try:
             print(startup_message.decode("utf-8"))
-        except UnicodeError:
-            raise _bleio.BluetoothError("Garbled HCI startup message")
+        except UnicodeError as exc:
+            raise _bleio.BluetoothError("Garbled HCI startup message") from exc
 
     # pylint: disable=no-member
     _bleio.adapter.hci_uart_init(uart=uart, rts=gpio0_and_rts, cts=cts)

--- a/adafruit_ble/hci.py
+++ b/adafruit_ble/hci.py
@@ -1,0 +1,113 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2020 Dan Halbert for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""
+Sets up an on-board HCI BLE adapter.
+"""
+
+import time
+
+import board
+import busio
+import digitalio
+import _bleio
+
+
+def esp32_hci_init(
+    *,
+    esp_reset=board.ESP_RESET,
+    esp_gpio0=board.ESP_GPIO0,
+    esp_busy=board.ESP_BUSY,
+    esp_cs=board.ESP_CS,
+    esp_tx=board.ESP_TX,
+    esp_rx=board.ESP_RX,
+    reset_high=False,
+    debug=False
+):
+    """Do ESP32-specific HCI adapter initialization."""
+
+    reset = digitalio.DigitalInOut(esp_reset)
+    reset.switch_to_output(not reset_high)
+
+    gpio0_and_rts = digitalio.DigitalInOut(esp_gpio0)
+    cts = digitalio.DigitalInOut(esp_busy)
+    chip_select = digitalio.DigitalInOut(esp_cs)
+
+    uart = busio.UART(
+        esp_tx, esp_rx, baudrate=115200, timeout=0, receiver_buffer_size=512
+    )
+
+    # Boot ESP32 from SPI flash.
+    gpio0_and_rts.switch_to_output(True)
+
+    # Choose Bluetooth mode.
+    chip_select.switch_to_output(False)
+
+    # Start reset
+    reset.value = reset_high
+    time.sleep(0.1)
+
+    # Release reset and wait for startup and startup message.
+    reset.value = not reset_high
+    time.sleep(1.0)
+
+    startup_message = b""
+    while uart.in_waiting:  # pylint: disable=no-member
+        more = uart.read()
+        if more:
+            startup_message += more
+
+    if not startup_message:
+        raise _bleio.BluetoothError(
+            "HCI adapter did not respond with a startup message"
+        )
+
+    if debug:
+        try:
+            print(startup_message.decode("utf-8"))
+        except UnicodeError:
+            raise _bleio.BluetoothError("Garbled HCI startup message")
+
+    # pylint: disable=no-member
+    _bleio.adapter.hci_uart_init(uart=uart, rts=gpio0_and_rts, cts=cts)
+
+
+def init(debug=False):
+    """Determine whether an on-board HCI adapter is available, and initialize it.
+    Currently only ESP32 co-processors are supported.
+    """
+    # See if all the pins we need for an ESP32 HCI adapter are available.
+    if all(
+        pin in dir(board)
+        for pin in ("ESP_RESET", "ESP_GPIO0", "ESP_BUSY", "ESP_CS", "ESP_TX", "ESP_RX")
+    ):
+        esp32_hci_init(
+            esp_reset=board.ESP_RESET,
+            esp_gpio0=board.ESP_GPIO0,
+            esp_busy=board.ESP_BUSY,
+            esp_cs=board.ESP_CS,
+            esp_tx=board.ESP_TX,
+            esp_rx=board.ESP_RX,
+            reset_high=False,
+            debug=debug,
+        )
+    else:
+        raise _bleio.BluetoothError("ESP32 HCI adapter pins not available")

--- a/examples/ble_bluefruit_color_picker.py
+++ b/examples/ble_bluefruit_color_picker.py
@@ -2,11 +2,13 @@
 
 import board
 import neopixel
+
+from adafruit_bluefruit_connect.packet import Packet
+from adafruit_bluefruit_connect.color_packet import ColorPacket
+
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 from adafruit_ble.services.nordic import UARTService
-from adafruit_bluefruit_connect.packet import Packet
-from adafruit_bluefruit_connect.color_packet import ColorPacket
 
 ble = BLERadio()
 uart_service = UARTService()

--- a/examples/ble_demo_central.py
+++ b/examples/ble_demo_central.py
@@ -10,12 +10,13 @@ import board
 import busio
 import digitalio
 import adafruit_lis3dh
-from adafruit_ble import BLERadio
-from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-from adafruit_ble.services.nordic import UARTService
 import neopixel
 
 from adafruit_bluefruit_connect.color_packet import ColorPacket
+
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
 
 
 def scale(value):

--- a/examples/ble_demo_periph.py
+++ b/examples/ble_demo_periph.py
@@ -6,13 +6,13 @@ and updates a Circuit Playground to show the history of the received packets.
 import board
 import neopixel
 
-from adafruit_ble import BLERadio
-from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-from adafruit_ble.services.nordic import UARTService
-
 # Only the packet classes that are imported will be known to Packet.
 from adafruit_bluefruit_connect.packet import Packet
 from adafruit_bluefruit_connect.color_packet import ColorPacket
+
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from adafruit_ble.services.nordic import UARTService
 
 NUM_PIXELS = 10
 np = neopixel.NeoPixel(board.NEOPIXEL, NUM_PIXELS, brightness=0.1)

--- a/examples/ble_hid_periph.py
+++ b/examples/ble_hid_periph.py
@@ -6,13 +6,15 @@ This example acts as a keyboard to peer devices.
 import sys
 import time
 
+from adafruit_hid.keyboard import Keyboard
+from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
+
 import adafruit_ble
 from adafruit_ble.advertising import Advertisement
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 from adafruit_ble.services.standard.hid import HIDService
 from adafruit_ble.services.standard.device_info import DeviceInfoService
-from adafruit_hid.keyboard import Keyboard
-from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
+
 
 # Use default HID descriptor
 hid = HIDService()


### PR DESCRIPTION
Goes with https://github.com/adafruit/circuitpython/pull/3310.

Add code to initialize a Bluetooth HCI adapter. The current pins should work for the on-board adapter on Metro M4 AirLift, PyPortals, and PyBadge AirLift. That is, all you need is:

```python
ble = BLERadio()
```

For an offboard AirLift breakout, the kind of code below works for now. We can think about changing this API to pass the pins to `BLERadio()`. I haven't thought about this API in detail yet.

```python
import _bleio
import board

hci.esp32_hci_init(
    esp_reset=board.D12,
    esp_gpio0=board.D10,
    esp_busy=board.D11,
    esp_cs=board.D13,
    esp_tx=board.TX,
    esp_rx=board.RX,
    debug=True)

# Must use initialized adapter explicitly.
ble = BLERadio(_bleio.adapter)
```
