### PR TITLE
Modified ManufacturerDataField to return a namedtuple if possible

### DIFF
--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -269,8 +269,8 @@ class ManufacturerDataField:
         self._entry_length = struct.calcsize(value_format)
         self.field_names = field_names
         if field_names:
-            # Mostly, this is to raise a ValueError if the passed-in field_names has invalid entries for later use.
-            self.MDFTuple = namedtuple("MDFTuple", self.field_names)
+            # Mostly, this is to raise a ValueError if field_names has invalid entries
+            self.mdf_tuple = namedtuple("mdf_tuple", self.field_names)
 
     def __get__(self, obj, cls):
         if obj is None:
@@ -283,11 +283,10 @@ class ManufacturerDataField:
             if self.element_count == 1:
                 unpacked = unpacked[0]
             if self.field_names and len(self.field_names) == len(unpacked):
-                # If we have field names, use them to make a namedtuple, and we should already have that defined.
+                # If we have field names, we should already have a namedtuple type to use
                 # Unless the element count is off, which... werid.
-                return self.MDFTuple(*unpacked)
-            else:
-                return unpacked
+                return self.mdf_tuple(*unpacked)
+            return unpacked
         if len(packed) % self._entry_length != 0:
             raise RuntimeError("Invalid data length")
         entry_count = len(packed) // self._entry_length


### PR DESCRIPTION
I'm definitely not convinced this covers all cases, nor am I convinced it's non-breaking, so I'm interested in feedback (but it does work neatly in my case).

If a given `Advertisement` subclass is defined with multiple fields in a single `ManufacturerDataField`, the current class requires it to have an array of `field_names`, which heretofore are unused.

This PR 1) enforces that `field_names` must be formatted properly for a namedtuple (i.e. no spaces, probably plenty of other things) and 2) returns a `MDFTuple` instead of a regular tuple, with fields named as defined. 

Mostly, I'm not sure when lines 285+ come into play, and whether they ought to be covered by the namedtuple modification. 