### PR TITLE
Handle entry properly for subclasses of Advertisement

### DIFF
--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -238,12 +238,6 @@ class Advertisement:
 
     def __init__(self, *, entry=None):
         """Create an empty advertising packet or one from a ScanEntry."""
-        self.data_dict = {}
-        self.address = None
-        self._rssi = None
-        self.connectable = False
-        self.mutable = True
-        self.scan_response = False
         if entry:
             self.data_dict = decode_data(entry.advertisement_bytes)
             self.address = entry.address
@@ -251,6 +245,13 @@ class Advertisement:
             self.connectable = entry.connectable
             self.scan_response = entry.scan_response
             self.mutable = False
+        else:
+            self.data_dict = {}
+            self.address = None
+            self._rssi = None
+            self.connectable = False
+            self.mutable = True
+            self.scan_response = False
 
     @property
     def rssi(self):

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -161,6 +161,11 @@ class ProvideServicesAdvertisement(Advertisement):
 
     def __init__(self, *services, entry=None):
         super().__init__(entry=entry)
+        if entry:
+            if services:
+                raise ValueError("Supply services or entry, not both")
+            # Attributes are supplied by entry.
+            return
         if services:
             self.services.extend(services)
         self.connectable = True
@@ -186,6 +191,11 @@ class SolicitServicesAdvertisement(Advertisement):
 
     def __init__(self, *services, entry=None):
         super().__init__(entry=entry)
+        if entry:
+            if services:
+                raise ValueError("Supply services or entry, not both")
+            # Attributes are supplied by entry.
+            return
         self.solicited_services.extend(services)
         self.connectable = True
         self.flags.general_discovery = True


### PR DESCRIPTION
If an `entry` is supplied to an `Advertisement` constructor, its values would override any default values, so only use the values passed in via the `entry`.

@kschmelzer Could you test to see if this fixes your problem?

Fixes #124.