### PR TITLE
Note that ble_uart_echo_test.py can be used with the Bluefruit Connect app

### DIFF
--- a/examples/ble_uart_echo_test.py
+++ b/examples/ble_uart_echo_test.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: MIT
 
 """
-Used with ble_uart_echo_client.py. Receives characters from the UARTService and transmits them back.
+Can be used with ble_uart_echo_client.py or with the UART page on the Adafruit Bluefruit Connect app.
+Receives characters from the UARTService and transmits them back.
 """
 
 from adafruit_ble import BLERadio


### PR DESCRIPTION
`ble_uart_echo_test.py` can be used with the Bluefruit Connect app for a simple test. Note this in docstring.