### PR TITLE
Connect to an address directly

### DIFF
--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -280,8 +280,7 @@ class BLERadio:
         """
         Initiates a `BLEConnection` to the peer that advertised the given advertisement.
 
-        :param Advertisement peer: An `Advertisement`, a subclass of `Advertisement`
-            or `_bleio.Address`
+        :param peer: An `Advertisement`, a subclass of `Advertisement` or `_bleio.Address`
         :param float timeout: how long to wait for a connection
         :return: the connection to the peer
         :rtype: BLEConnection

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -276,16 +276,18 @@ class BLERadio:
         once empty."""
         self._adapter.stop_scan()
 
-    def connect(self, advertisement, *, timeout=4.0):
+    def connect(self, peer, *, timeout=4.0):
         """
         Initiates a `BLEConnection` to the peer that advertised the given advertisement.
 
-        :param advertisement Advertisement: An `Advertisement` or a subclass of `Advertisement`
-        :param timeout float: how long to wait for a connection
+        :param Advertisement peer: An `Advertisement`, a subclass of `Advertisement` or `Address`
+        :param float timeout: how long to wait for a connection
         :return: the connection to the peer
         :rtype: BLEConnection
         """
-        connection = self._adapter.connect(advertisement.address, timeout=timeout)
+        if not isinstance(peer, _bleio.Address):
+            peer = peer.address
+        connection = self._adapter.connect(peer, timeout=timeout)
         self._connection_cache[connection] = BLEConnection(connection)
         return self._connection_cache[connection]
 

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -32,7 +32,7 @@ class BLEConnection:
     Represents a connection to a peer BLE device.
     It acts as a map from a `Service` type to a `Service` instance for the connection.
 
-    :param bleio_connection _bleio.Connection: the native `_bleio.Connection` object to wrap
+    :param _bleio.Connection bleio_connection: the native `_bleio.Connection` object to wrap
 
     """
 
@@ -227,15 +227,15 @@ class BLERadio:
         :param float timeout: the scan timeout in seconds.
             If None, will scan until `stop_scan` is called.
         :param float interval: the interval (in seconds) between the start
-             of two consecutive scan windows
-             Must be in the range 0.0025 - 40.959375 seconds.
+            of two consecutive scan windows
+            Must be in the range 0.0025 - 40.959375 seconds.
         :param float window: the duration (in seconds) to scan a single BLE channel.
-             window must be <= interval.
+            window must be <= interval.
         :param int minimum_rssi: the minimum rssi of entries to return.
         :param bool active: request and retrieve scan responses for scannable advertisements.
         :return: If any ``advertisement_types`` are given,
-           only Advertisements of those types are produced by the returned iterator.
-           If none are given then `Advertisement` objects will be returned.
+            only Advertisements of those types are produced by the returned iterator.
+            If none are given then `Advertisement` objects will be returned.
         :rtype: iterable
         """
         if not advertisement_types:
@@ -280,7 +280,8 @@ class BLERadio:
         """
         Initiates a `BLEConnection` to the peer that advertised the given advertisement.
 
-        :param Advertisement peer: An `Advertisement`, a subclass of `Advertisement` or `Address`
+        :param Advertisement peer: An `Advertisement`, a subclass of `Advertisement`
+            or `_bleio.Address`
         :param float timeout: how long to wait for a connection
         :return: the connection to the peer
         :rtype: BLEConnection

--- a/examples/ble_uart_echo_test.py
+++ b/examples/ble_uart_echo_test.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 """
-Can be used with ble_uart_echo_client.py or with the UART page on the Adafruit Bluefruit Connect app.
-Receives characters from the UARTService and transmits them back.
+Can be used with ble_uart_echo_client.py or with the UART page on the
+Adafruit Bluefruit Connect app. Receives characters from the UARTService
+and transmits them back.
 """
 
 from adafruit_ble import BLERadio


### PR DESCRIPTION
This is helpful for reconnecting to a device we had already
connected to. The `connect()` call will do its own scan when
connecting.