### PR TITLE
python 3.7 for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@
 version: 2
 
 python:
-  version: "3.6"
+  version: "3.7"
   install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt


### PR DESCRIPTION
This updates the RTD config to instruct their system to use python 3.7. I think this will resolve #143 

I went with specifically 3.7 because that appears to be the version in use inside of github actions, so hopefully we will see the same results from actions as we can expect to get from the RTD build with this version.