### PR TITLE
Add missing files to ReadTheDocs

### DIFF
--- a/adafruit_ble/services/sphero.py
+++ b/adafruit_ble/services/sphero.py
@@ -20,4 +20,4 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class SpheroService(Service):
     """Core Sphero Service. Unimplemented."""
 
-    uuid = VendorUUID("!!orehpS OOW\x01\x00\x01\x00")
+    uuid = VendorUUID(b"!!orehpS OOW\x01\x00\x01\x00")

--- a/docs/characteristics.rst
+++ b/docs/characteristics.rst
@@ -7,6 +7,9 @@
 .. automodule:: adafruit_ble.characteristics.int
    :members:
 
+.. automodule:: adafruit_ble.characteristics.float
+   :members:
+
 .. automodule:: adafruit_ble.characteristics.stream
    :members:
 

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -17,3 +17,6 @@
 
 .. automodule:: adafruit_ble.services.midi
   :members:
+
+.. automodule:: adafruit_ble.services.nordic
+  :memebers:

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -19,7 +19,7 @@
   :members:
 
 .. automodule:: adafruit_ble.services.nordic
-  :memebers:
+  :members:
 
 .. automodule:: adafruit_ble.services.sphero
-  :memebers:
+  :members:

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -20,6 +20,3 @@
 
 .. automodule:: adafruit_ble.services.nordic
   :members:
-
-.. automodule:: adafruit_ble.services.sphero
-  :members:

--- a/docs/services.rst
+++ b/docs/services.rst
@@ -20,3 +20,6 @@
 
 .. automodule:: adafruit_ble.services.nordic
   :memebers:
+
+.. automodule:: adafruit_ble.services.sphero
+  :memebers:


### PR DESCRIPTION
Addresses Issue #148 with the following changes:

1. Adds `adafruit_blue.characteristics.float` to ReadTheDocs
2. Adds `adafruit_blue.services.nordic` to ReadTheDocs
3. Changes input to `VendorUUID` in `SpheroService` class variable from `str` to `bytes` as it should be, but I ultimately decided to keep in unlisted in ReadTheDocs because the file/class is unimplmented and I couldn't find it being used in any adafruit repos.