### PR TITLE
Implement Advertisement.__eq__()

### DIFF
--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -301,6 +301,11 @@ class Advertisement:
         """The raw packet bytes."""
         return encode_data(self.data_dict)
 
+    def __eq__(self, other):
+        if isinstance(other, Advertisement):
+            return self.data_dict == self.data_dict
+        return False
+
     def __str__(self):
         parts = []
         for attr in dir(self.__class__):

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -303,7 +303,7 @@ class Advertisement:
 
     def __eq__(self, other):
         if isinstance(other, Advertisement):
-            return self.data_dict == self.data_dict
+            return self.data_dict == other.data_dict
         return False
 
     def __str__(self):


### PR DESCRIPTION
Addresses Issue #85 by adding `__eq__()` for Advertisement.  Since the workaround was to compare `bytes(adv1) == bytes(adv2)`, I implemented `__eq__()` to check the `Advertisement.data_dict` that gets encoded to bytes for equality. 

Did not test, I could if someone could recommend a good test of use case for this since I'm fairly new to this library.