### PR TITLE
Expose Adafruit advertising constants

### DIFF
--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -45,8 +45,7 @@ class AdafruitColor(Advertisement):
         ManufacturerData,
         "manufacturer_data",
         advertising_data_type=MANUFACTURING_DATA_ADT,
-        company_id=
-    ADAFRUIT_COMPANY_ID,
+        company_id=ADAFRUIT_COMPANY_ID,
         key_encoding="<H",
     )
     color = ManufacturerDataField(_COLOR_DATA_ID, "<I")

--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -23,8 +23,8 @@ from .standard import ManufacturerData, ManufacturerDataField
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
-_MANUFACTURING_DATA_ADT = const(0xFF)
-_ADAFRUIT_COMPANY_ID = const(0x0822)
+MANUFACTURING_DATA_ADT = const(0xFF)
+ADAFRUIT_COMPANY_ID = const(0x0822)
 _COLOR_DATA_ID = const(0x0000)
 
 
@@ -35,8 +35,8 @@ class AdafruitColor(Advertisement):
     match_prefixes = (
         struct.pack(
             "<BHBH",
-            _MANUFACTURING_DATA_ADT,
-            _ADAFRUIT_COMPANY_ID,
+            MANUFACTURING_DATA_ADT,
+            ADAFRUIT_COMPANY_ID,
             struct.calcsize("<HI"),
             _COLOR_DATA_ID,
         ),
@@ -44,8 +44,9 @@ class AdafruitColor(Advertisement):
     manufacturer_data = LazyObjectField(
         ManufacturerData,
         "manufacturer_data",
-        advertising_data_type=_MANUFACTURING_DATA_ADT,
-        company_id=_ADAFRUIT_COMPANY_ID,
+        advertising_data_type=MANUFACTURING_DATA_ADT,
+        company_id=
+    ADAFRUIT_COMPANY_ID,
         key_encoding="<H",
     )
     color = ManufacturerDataField(_COLOR_DATA_ID, "<I")

--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -24,7 +24,11 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 MANUFACTURING_DATA_ADT = const(0xFF)
+"""The advertising data type for manufacturer-specific data"""
+
 ADAFRUIT_COMPANY_ID = const(0x0822)
+"""Company Identifier for Adafruit Industries"""
+
 _COLOR_DATA_ID = const(0x0000)
 
 


### PR DESCRIPTION
Addresses Enhancement Issue #83 by exposing the Adafruit constants.  My understanding is this can be done by removing the preceding `_`.

It may be worth considering creating issues for applicable libraries to use these newly exposed constants, if merged.  Happy to create them (and likely PR them) if so!