### PR TITLE
Remove incorrect parameter docs for UARTService.__init__()

### DIFF
--- a/adafruit_ble/services/nordic.py
+++ b/adafruit_ble/services/nordic.py
@@ -23,11 +23,6 @@ class UARTService(Service):
     """
     Provide UART-like functionality via the Nordic NUS service.
 
-    :param int timeout:  the timeout in seconds to wait
-      for the first character and between subsequent characters.
-    :param int buffer_size: buffer up to this many bytes.
-      If more bytes are received, older bytes will be discarded.
-
     See ``examples/ble_uart_echo_test.py`` for a usage example.
     """
 


### PR DESCRIPTION
Discord user rk3d tried to use a timeout parameter in the UARTService that did not actually exist.