### PR TITLE
Add JSON characteristic

### DIFF
--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -1,0 +1,53 @@
+"""
+`json`
+====================================================
+
+This module provides Json characteristic.
+
+"""
+
+import json
+from . import Attribute
+from . import Characteristic
+
+__version__ = "0.0.0-auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
+
+
+class JsonCharacteristic(Characteristic):
+    """Json string characteristic."""
+
+    def __init__(
+        self,
+        *,
+        uuid=None,
+        properties=Characteristic.READ,
+        read_perm=Attribute.OPEN,
+        write_perm=Attribute.OPEN,
+        initial_value=None,
+    ):
+        super().__init__(
+            uuid=uuid,
+            properties=properties,
+            read_perm=read_perm,
+            write_perm=write_perm,
+            max_length=512,
+            fixed_length=False,
+            initial_value=self.pack(initial_value),
+        )
+
+    @staticmethod
+    def pack(value):
+        return json.dumps(value).encode("utf-8")
+
+    @staticmethod
+    def unpack(value):
+        return json.loads(str(value, "utf-8"))
+
+    def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
+        return self.unpack(super().__get__(obj, cls))
+
+    def __set__(self, obj, value):
+        super().__set__(obj, self.pack(value))

--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -6,7 +6,7 @@
 `json`
 ====================================================
 
-This module provides JSON characteristic.
+This module provides a JSON characteristic for reading/writing JSON serializable Python values.
 
 """
 

--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Mark Raleson
+#
+# SPDX-License-Identifier: MIT
+
 """
 `json`
 ====================================================

--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -6,7 +6,7 @@
 `json`
 ====================================================
 
-This module provides Json characteristic.
+This module provides JSON characteristic.
 
 """
 
@@ -18,8 +18,8 @@ __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 
-class JsonCharacteristic(Characteristic):
-    """Json string characteristic for JSON serializable values of a limited size (max_length)."""
+class JSONCharacteristic(Characteristic):
+    """JSON string characteristic for JSON serializable values of a limited size (max_length)."""
 
     def __init__(
         self,

--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -19,7 +19,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 
 class JsonCharacteristic(Characteristic):
-    """Json string characteristic."""
+    """Json string characteristic for JSON serializable values of a limited size (max_length)."""
 
     def __init__(
         self,

--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -42,10 +42,12 @@ class JsonCharacteristic(Characteristic):
 
     @staticmethod
     def pack(value):
+        """Converts a JSON serializable python value into a utf-8 encoded JSON string."""
         return json.dumps(value).encode("utf-8")
 
     @staticmethod
     def unpack(value):
+        """Converts a utf-8 encoded JSON string into a python value."""
         return json.loads(str(value, "utf-8"))
 
     def __get__(self, obj, cls=None):

--- a/examples/ble_json_central.py
+++ b/examples/ble_json_central.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Read sensor readings from peripheral BLE device using JSON characteristic.
+# Read sensor readings from peripheral BLE device using a JSON characteristic.
 
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement

--- a/examples/ble_json_central.py
+++ b/examples/ble_json_central.py
@@ -25,8 +25,6 @@ while True:
 
     if connection and connection.connected:
         service = connection[SensorService]
-        service.settings = {
-            'unit': 'celsius' #  'fahrenheit'
-        }
+        service.settings = {"unit": "celsius"}  #  'fahrenheit'
         while connection.connected:
-            print('Sensors: ', service.sensors)
+            print("Sensors: ", service.sensors)

--- a/examples/ble_json_central.py
+++ b/examples/ble_json_central.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2020 Mark Raleson
+#
+# SPDX-License-Identifier: MIT
+
+# Read sensor readings from peripheral BLE device using JSON characteristic.
+
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from ble_json_service import SensorService
+
+
+ble = BLERadio()
+connection = None
+
+while True:
+
+    if not connection:
+        print("Scanning for BLE device advertising our sensor service...")
+        for adv in ble.start_scan(ProvideServicesAdvertisement):
+            if SensorService in adv.services:
+                connection = ble.connect(adv)
+                print("Connected")
+                break
+        ble.stop_scan()
+
+    if connection and connection.connected:
+        service = connection[SensorService]
+        service.settings = {
+            'unit': 'celsius' #  'fahrenheit'
+        }
+        while connection.connected:
+            print('Sensors: ', service.sensors)

--- a/examples/ble_json_central.py
+++ b/examples/ble_json_central.py
@@ -4,9 +4,9 @@
 
 # Read sensor readings from peripheral BLE device using a JSON characteristic.
 
+from ble_json_service import SensorService
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-from ble_json_service import SensorService
 
 
 ble = BLERadio()

--- a/examples/ble_json_peripheral.py
+++ b/examples/ble_json_peripheral.py
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2020 Mark Raleson
+#
+# SPDX-License-Identifier: MIT
+
+# Provide readable sensor values and writable settings to connected devices via Json characteristic.
+
+import time
+import random
+from adafruit_ble import BLERadio
+from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
+from ble_json_service import SensorService
+
+
+# Create BLE radio, custom service, and advertisement.
+ble = BLERadio()
+service = SensorService()
+advertisement = ProvideServicesAdvertisement(service)
+
+# Function to get some fake weather sensor readings for this example in the desired unit.
+def measure(unit):
+    temperature = random.uniform(0.0, 10.0)
+    humidity = random.uniform(0.0, 100.0)
+    if unit == 'fahrenheit':
+        temperature = (temperature * 9.0 / 5.0) + 32.0
+    return {
+        'temperature': temperature,
+        'humidity': humidity
+    }
+
+# Advertise until another device connects, when a device connects, provide sensor data.
+while True:
+    print('Advertise services')
+    ble.stop_advertising() # you need to do this to stop any persistent old advertisement
+    ble.start_advertising(advertisement)
+
+    print("Waiting for connection...")
+    while not ble.connected:
+        pass
+
+    print("Connected")
+    while ble.connected:
+        settings = service.settings
+        measurement = measure(settings.get('unit', 'celsius'))
+        service.sensors = measurement
+        print('Settings: ', settings)
+        print('Sensors: ', measurement)
+        time.sleep(.25)
+
+    print('Disconnected')

--- a/examples/ble_json_peripheral.py
+++ b/examples/ble_json_peripheral.py
@@ -20,17 +20,15 @@ advertisement = ProvideServicesAdvertisement(service)
 def measure(unit):
     temperature = random.uniform(0.0, 10.0)
     humidity = random.uniform(0.0, 100.0)
-    if unit == 'fahrenheit':
+    if unit == "fahrenheit":
         temperature = (temperature * 9.0 / 5.0) + 32.0
-    return {
-        'temperature': temperature,
-        'humidity': humidity
-    }
+    return {"temperature": temperature, "humidity": humidity}
+
 
 # Advertise until another device connects, when a device connects, provide sensor data.
 while True:
-    print('Advertise services')
-    ble.stop_advertising() # you need to do this to stop any persistent old advertisement
+    print("Advertise services")
+    ble.stop_advertising()  # you need to do this to stop any persistent old advertisement
     ble.start_advertising(advertisement)
 
     print("Waiting for connection...")
@@ -40,10 +38,10 @@ while True:
     print("Connected")
     while ble.connected:
         settings = service.settings
-        measurement = measure(settings.get('unit', 'celsius'))
+        measurement = measure(settings.get("unit", "celsius"))
         service.sensors = measurement
-        print('Settings: ', settings)
-        print('Sensors: ', measurement)
-        time.sleep(.25)
+        print("Settings: ", settings)
+        print("Sensors: ", measurement)
+        time.sleep(0.25)
 
-    print('Disconnected')
+    print("Disconnected")

--- a/examples/ble_json_peripheral.py
+++ b/examples/ble_json_peripheral.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-# Provide readable sensor values and writable settings to connected devices via Json characteristic.
+# Provide readable sensor values and writable settings to connected devices via JSON characteristic.
 
 import time
 import random

--- a/examples/ble_json_peripheral.py
+++ b/examples/ble_json_peripheral.py
@@ -6,9 +6,9 @@
 
 import time
 import random
+from ble_json_service import SensorService
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-from ble_json_service import SensorService
 
 
 # Create BLE radio, custom service, and advertisement.

--- a/examples/ble_json_service.py
+++ b/examples/ble_json_service.py
@@ -1,0 +1,30 @@
+from adafruit_ble.uuid import VendorUUID
+from adafruit_ble.services import Service
+from adafruit_ble.characteristics import Characteristic
+from adafruit_ble.characteristics.json import JsonCharacteristic
+
+
+# A custom service with two Json characteristics for this device.  The "sensors" characteristic
+# provides updated sensor values for any connected device to read.  The "settings" characteristic
+# can be changed by any connected device to update the peripheral's settings.  The UUID of your
+# service can be any valid random uuid (some BLE UUID's are reserved).
+# NOTE: Json data is limited by characteristic max_length of 512 byes.
+class SensorService(Service):
+    uuid = VendorUUID("51ad213f-e568-4e35-84e4-67af89c79ef0")
+
+    settings = JsonCharacteristic(
+        uuid=VendorUUID("e077bdec-f18b-4944-9e9e-8b3a815162b4"),
+        properties=Characteristic.READ | Characteristic.WRITE,
+        initial_value={
+            'unit': 'celsius'
+        }
+    )
+
+    sensors = JsonCharacteristic(
+        uuid=VendorUUID("528ff74b-fdb8-444c-9c64-3dd5da4135ae"),
+        properties=Characteristic.READ,
+    )
+
+    def __init__(self, service=None):
+        super().__init__(service=service)
+        self.connectable = True

--- a/examples/ble_json_service.py
+++ b/examples/ble_json_service.py
@@ -1,18 +1,18 @@
 from adafruit_ble.uuid import VendorUUID
 from adafruit_ble.services import Service
 from adafruit_ble.characteristics import Characteristic
-from adafruit_ble.characteristics.json import JsonCharacteristic
+from adafruit_ble.characteristics.json import JSONCharacteristic
 
 
-# A custom service with two Json characteristics for this device.  The "sensors" characteristic
+# A custom service with two JSON characteristics for this device.  The "sensors" characteristic
 # provides updated sensor values for any connected device to read.  The "settings" characteristic
 # can be changed by any connected device to update the peripheral's settings.  The UUID of your
 # service can be any valid random uuid (some BLE UUID's are reserved).
-# NOTE: Json data is limited by characteristic max_length of 512 byes.
+# NOTE: JSON data is limited by characteristic max_length of 512 byes.
 class SensorService(Service):
     uuid = VendorUUID("51ad213f-e568-4e35-84e4-67af89c79ef0")
 
-    settings = JsonCharacteristic(
+    settings = JSONCharacteristic(
         uuid=VendorUUID("e077bdec-f18b-4944-9e9e-8b3a815162b4"),
         properties=Characteristic.READ | Characteristic.WRITE,
         initial_value={
@@ -20,7 +20,7 @@ class SensorService(Service):
         }
     )
 
-    sensors = JsonCharacteristic(
+    sensors = JSONCharacteristic(
         uuid=VendorUUID("528ff74b-fdb8-444c-9c64-3dd5da4135ae"),
         properties=Characteristic.READ,
     )

--- a/examples/ble_json_service.py
+++ b/examples/ble_json_service.py
@@ -10,6 +10,8 @@ from adafruit_ble.characteristics.json import JSONCharacteristic
 # service can be any valid random uuid (some BLE UUID's are reserved).
 # NOTE: JSON data is limited by characteristic max_length of 512 byes.
 class SensorService(Service):
+    # pylint: disable=too-few-public-methods
+
     uuid = VendorUUID("51ad213f-e568-4e35-84e4-67af89c79ef0")
 
     settings = JSONCharacteristic(

--- a/examples/ble_json_service.py
+++ b/examples/ble_json_service.py
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2020 Mark Raleson
+#
+# SPDX-License-Identifier: MIT
+
+# Read sensor readings from peripheral BLE device using a JSON characteristic.
+
 from adafruit_ble.uuid import VendorUUID
 from adafruit_ble.services import Service
 from adafruit_ble.characteristics import Characteristic

--- a/examples/ble_json_service.py
+++ b/examples/ble_json_service.py
@@ -23,9 +23,7 @@ class SensorService(Service):
     settings = JSONCharacteristic(
         uuid=VendorUUID("e077bdec-f18b-4944-9e9e-8b3a815162b4"),
         properties=Characteristic.READ | Characteristic.WRITE,
-        initial_value={
-            'unit': 'celsius'
-        }
+        initial_value={"unit": "celsius"},
     )
 
     sensors = JSONCharacteristic(


### PR DESCRIPTION
Adds a JSON characteristic so python arrays, dicts, etc can be set/get easily on a connected ble device. This was very helpful for fast prototyping and debugging.  I found it difficult to send large values of the UART due to the small buffer, lack of flow control, reliable messaging etc.  It also has an advantage over making many individual characteristics, the Nordic chip I was using on the Feather Sense was unable to support the number of individual characteristics I needed without running out of memory.  I also considered a msgpack variant, but it didn't save enough space for me to justify the lack of debugging utility.  One consideration is the size is limited by the characteristic buffer size.