### PR TITLE
Hyperspecify targets in documentation

### DIFF
--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -206,8 +206,8 @@ class Advertisement:
     """
 
     match_prefixes = ()
-    """For Advertisement, `Advertisement.matches` will always return ``True``.
-    Subclasses may override this value."""
+    """For Advertisement, :py:attr:`~adafruit_ble.advertising.Advertisement.match_prefixes`
+    will always return ``True``. Subclasses may override this value."""
     # cached bytes of merged prefixes.
     _prefix_bytes = None
 

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -207,7 +207,9 @@ class ManufacturerData(AdvertisingDataField):
     company_id and the data is structured like an advertisement with a configurable key
     format. The order of the serialized data is determined by the order that the
     `ManufacturerDataField` attributes are set in - this can be useful for
-    `Advertisement.match_prefixes` in an `Advertisement` sub-class."""
+    :py:attr:`~adafruit_ble.advertising.Advertisement.match_prefixes` in an `Advertisement`
+    sub-class.
+    """
 
     def __init__(
         self, obj, *, advertising_data_type=0xFF, company_id, key_encoding="B"


### PR DESCRIPTION
Will resolve documentation issues in other libraries that don't have their own docstrings for `match_prefixes`