### PR TITLE
Add type annotations

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -252,7 +252,7 @@ ignore-docstrings=yes
 ignore-imports=yes
 
 # Minimum lines number of a similarity.
-min-similarity-lines=12
+min-similarity-lines=16
 
 
 [BASIC]

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -9,7 +9,11 @@ This module provides higher-level BLE (Bluetooth Low Energy) functionality,
 building on the native `_bleio` module.
 
 """
+
+from __future__ import annotations
+
 # pylint: disable=wrong-import-position
+
 import sys
 
 if sys.implementation.name == "circuitpython" and sys.implementation.version[0] <= 4:
@@ -24,10 +28,14 @@ from .services import Service
 from .advertising import Advertisement
 
 try:
-    from typing import Optional, Iterator, Union, Tuple, Literal, NoReturn
-    from circuitpython_typing import ReadableBuffer
-    from adafruit_ble.uuid import UUID
-    from adafruit_ble.characteristics import Characteristic
+    from typing import Optional, Iterator, Union, Tuple, NoReturn, TYPE_CHECKING
+    from typing_extensions import Literal
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer
+        from adafruit_ble.uuid import UUID
+        from adafruit_ble.characteristics import Characteristic
+
 except ImportError:
     pass
 
@@ -220,7 +228,7 @@ class BLERadio:
         interval: float = 0.1,
         window: float = 0.1,
         minimum_rssi: int = -80,
-        active: bool = True
+        active: bool = True,
     ) -> Iterator[Advertisement]:
         """
         Starts scanning. Returns an iterator of advertisement objects of the types given in

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -157,7 +157,11 @@ class BLERadio:
         self._connection_cache = {}
 
     def start_advertising(
-        self, advertisement: Advertisement, scan_response: Optional[ReadableBuffer] = None, interval: float = 0.1, timeout: Optional[int] = None
+        self,
+        advertisement: Advertisement,
+        scan_response: Optional[ReadableBuffer] = None,
+        interval: float = 0.1,
+        timeout: Optional[int] = None,
     ) -> None:
         """
         Starts advertising the given advertisement.
@@ -284,7 +288,9 @@ class BLERadio:
         once empty."""
         self._adapter.stop_scan()
 
-    def connect(self, peer: Union[Advertisement, _bleio.Address], *, timeout:float = 4.0) -> BLEConnection:
+    def connect(
+        self, peer: Union[Advertisement, _bleio.Address], *, timeout: float = 4.0
+    ) -> BLEConnection:
         """
         Initiates a `BLEConnection` to the peer that advertised the given advertisement.
 

--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -59,7 +59,7 @@ class BLEConnection:
         # Service objects that wrap remote services.
         self._constructed_services = {}
 
-    def _discover_remote(self, uuid: UUID) -> Optional[Service]:
+    def _discover_remote(self, uuid: UUID) -> Optional[_bleio.Service]:
         remote_service = None
         if uuid in self._discovered_bleio_services:
             remote_service = self._discovered_bleio_services[uuid]
@@ -72,7 +72,7 @@ class BLEConnection:
                 self._discovered_bleio_services[uuid] = remote_service
         return remote_service
 
-    def __contains__(self, key: Union[UUID, Characteristic]) -> bool:
+    def __contains__(self, key: Union[UUID, Service]) -> bool:
         """
         Allows easy testing for a particular Service class or a particular UUID
         associated with this connection.
@@ -90,7 +90,7 @@ class BLEConnection:
             uuid = key.uuid
         return self._discover_remote(uuid) is not None
 
-    def __getitem__(self, key: Union[UUID, Characteristic]) -> Optional[Service]:
+    def __getitem__(self, key: Union[UUID, Service]) -> Optional[Service]:
         """Return the Service for the given Service class or uuid, if any."""
         uuid = key
         maybe_service = False

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -28,7 +28,9 @@ def to_bytes_literal(seq: bytes) -> str:
     return 'b"' + "".join("\\x{:02x}".format(v) for v in seq) + '"'
 
 
-def decode_data(data: bytes, *, key_encoding: str = "B") -> Dict[Any, Union[bytes, List[bytes]]]:
+def decode_data(
+    data: bytes, *, key_encoding: str = "B"
+) -> Dict[Any, Union[bytes, List[bytes]]]:
     """Helper which decodes length encoded structures into a dictionary with the given key
     encoding."""
     i = 0
@@ -51,7 +53,9 @@ def decode_data(data: bytes, *, key_encoding: str = "B") -> Dict[Any, Union[byte
     return data_dict
 
 
-def compute_length(data_dict: Dict[Any, Union[bytes, List[bytes]]], *, key_encoding: str = "B") -> int:
+def compute_length(
+    data_dict: Dict[Any, Union[bytes, List[bytes]]], *, key_encoding: str = "B"
+) -> int:
     """Computes the length of the encoded data dictionary."""
     value_size = 0
     for value in data_dict.values():
@@ -63,7 +67,9 @@ def compute_length(data_dict: Dict[Any, Union[bytes, List[bytes]]], *, key_encod
     return len(data_dict) + len(data_dict) * struct.calcsize(key_encoding) + value_size
 
 
-def encode_data(data_dict: Dict[Any, Union[bytes, List[bytes]]], *, key_encoding: str = "B") -> bytes:
+def encode_data(
+    data_dict: Dict[Any, Union[bytes, List[bytes]]], *, key_encoding: str = "B"
+) -> bytes:
     """Helper which encodes dictionaries into length encoded structures with the given key
     encoding."""
     length = compute_length(data_dict, key_encoding=key_encoding)
@@ -92,7 +98,9 @@ class AdvertisingFlag:
     def __init__(self, bit_position: int) -> None:
         self._bitmask = 1 << bit_position
 
-    def __get__(self, obj: Optional["AdvertisingFlags"], cls: Type["AdvertisingFlags"]) -> Union[bool, "AdvertisingFlag"]:
+    def __get__(
+        self, obj: Optional["AdvertisingFlags"], cls: Type["AdvertisingFlags"]
+    ) -> Union[bool, "AdvertisingFlag"]:
         if obj is None:
             return self
         return (obj.flags & self._bitmask) != 0
@@ -115,7 +123,9 @@ class AdvertisingFlags(AdvertisingDataField):
     """BR/EDR not supported."""
     # BR/EDR flags not included here, since we don't support BR/EDR.
 
-    def __init__(self, advertisement: "Advertisement", advertising_data_type: int) -> None:
+    def __init__(
+        self, advertisement: "Advertisement", advertising_data_type: int
+    ) -> None:
         self._advertisement = advertisement
         self._adt = advertising_data_type
         self.flags = 0
@@ -146,7 +156,9 @@ class String(AdvertisingDataField):
     def __init__(self, *, advertising_data_type: int) -> None:
         self._adt = advertising_data_type
 
-    def __get__(self, obj: Optional["Advertisement"], cls: Type["Advertisement"]) -> Optional[Union[str, "String"]]:
+    def __get__(
+        self, obj: Optional["Advertisement"], cls: Type["Advertisement"]
+    ) -> Optional[Union[str, "String"]]:
         if obj is None:
             return self
         if self._adt not in obj.data_dict:
@@ -164,7 +176,9 @@ class Struct(AdvertisingDataField):
         self._format = struct_format
         self._adt = advertising_data_type
 
-    def __get__(self, obj: Optional["Advertisement"], cls: Type["Advertisement"]) -> Optional[Union[Any, "Struct"]]:
+    def __get__(
+        self, obj: Optional["Advertisement"], cls: Type["Advertisement"]
+    ) -> Optional[Union[Any, "Struct"]]:
         if obj is None:
             return self
         if self._adt not in obj.data_dict:
@@ -178,13 +192,17 @@ class Struct(AdvertisingDataField):
 class LazyObjectField(AdvertisingDataField):
     """Non-data descriptor useful for lazily binding a complex object to an advertisement object."""
 
-    def __init__(self, cls: Any, attribute_name: str, *, advertising_data_type: int, **kwargs) -> None:
+    def __init__(
+        self, cls: Any, attribute_name: str, *, advertising_data_type: int, **kwargs
+    ) -> None:
         self._cls = cls
         self._attribute_name = attribute_name
         self._adt = advertising_data_type
         self._kwargs = kwargs
 
-    def __get__(self, obj: Optional["Advertisement"], cls: Type["Advertisement"]) -> Any:
+    def __get__(
+        self, obj: Optional["Advertisement"], cls: Type["Advertisement"]
+    ) -> Any:
         if obj is None:
             return self
         # Return None if our object is immutable and the data is not present.

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -6,13 +6,18 @@
 Advertising is the first phase of BLE where devices can broadcast
 """
 
+from __future__ import annotations
+
 import struct
 
 try:
-    from typing import Dict, Any, Union, List, Optional, Type, Literal, TypeVar
-    from _bleio import ScanEntry
+    from typing import Dict, Any, Union, List, Optional, Type, TypeVar, TYPE_CHECKING
+    from typing_extensions import Literal
 
-    LazyObjectField_GivenClass = TypeVar("LazyObjectField_GivenClass")
+    if TYPE_CHECKING:
+        from _bleio import ScanEntry
+
+        LazyObjectField_GivenClass = TypeVar("LazyObjectField_GivenClass")
 
 except ImportError:
     pass

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -26,7 +26,6 @@ from ..uuid import StandardUUID, VendorUUID
 
 try:
     from typing import Optional, List, Tuple, Union, Type, Iterator, Iterable, Any
-    from typing_extensions import Protocol
     from adafruit_ble.uuid import UUID
     from adafruit_ble.characteristics import Characteristic
     from adafruit_ble.services import Service

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -32,8 +32,9 @@ try:
     from adafruit_ble.services import Service
     from _bleio import ScanEntry
 
-    UsesServicesAdvertisement = Union["ProvideServicesAdvertisement", "SolicitServicesAdvertisement"]
-
+    UsesServicesAdvertisement = Union[
+        "ProvideServicesAdvertisement", "SolicitServicesAdvertisement"
+    ]
 
 
 except ImportError:
@@ -46,7 +47,13 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class BoundServiceList:
     """Sequence-like object of Service UUID objects. It stores both standard and vendor UUIDs."""
 
-    def __init__(self, advertisement: UsesServicesAdvertisement, *, standard_services: List[int], vendor_services: List[int]) -> None:
+    def __init__(
+        self,
+        advertisement: UsesServicesAdvertisement,
+        *,
+        standard_services: List[int],
+        vendor_services: List[int]
+    ) -> None:
         self._advertisement = advertisement
         self._standard_service_fields = standard_services
         self._vendor_service_fields = vendor_services
@@ -140,7 +147,9 @@ class BoundServiceList:
 class ServiceList(AdvertisingDataField):
     """Descriptor for a list of Service UUIDs that lazily binds a corresponding BoundServiceList."""
 
-    def __init__(self, *, standard_services: List[int], vendor_services: List[int]) -> None:
+    def __init__(
+        self, *, standard_services: List[int], vendor_services: List[int]
+    ) -> None:
         self.standard_services = standard_services
         self.vendor_services = vendor_services
 
@@ -153,7 +162,11 @@ class ServiceList(AdvertisingDataField):
                 return True
         return False
 
-    def __get__(self, obj: Optional[UsesServicesAdvertisement], cls: Type[UsesServicesAdvertisement]) -> Union[UsesServicesAdvertisement, Tuple[()], "ServiceList"]:
+    def __get__(
+        self,
+        obj: Optional[UsesServicesAdvertisement],
+        cls: Type[UsesServicesAdvertisement],
+    ) -> Union[UsesServicesAdvertisement, Tuple[()], "ServiceList"]:
         if obj is None:
             return self
         if not self._present(obj) and not obj.mutable:
@@ -227,7 +240,12 @@ class ManufacturerData(AdvertisingDataField):
     """
 
     def __init__(
-        self, obj: UsesServicesAdvertisement, *, advertising_data_type: int = 0xFF, company_id: int, key_encoding: str = "B"
+        self,
+        obj: UsesServicesAdvertisement,
+        *,
+        advertising_data_type: int = 0xFF,
+        company_id: int,
+        key_encoding: str = "B"
     ) -> None:
         self._obj = obj
         self._company_id = company_id
@@ -264,7 +282,9 @@ class ManufacturerData(AdvertisingDataField):
 class ManufacturerDataField:
     """A single piece of data within the manufacturer specific data. The format can be repeated."""
 
-    def __init__(self, key: int, value_format: str, field_names: Optional[Iterable[str]] = None) -> None:
+    def __init__(
+        self, key: int, value_format: str, field_names: Optional[Iterable[str]] = None
+    ) -> None:
         self._key = key
         self._format = value_format
         # TODO: Support format strings that use numbers to repeat a given type. For now, we strip
@@ -282,7 +302,9 @@ class ManufacturerDataField:
             # Mostly, this is to raise a ValueError if field_names has invalid entries
             self.mdf_tuple = namedtuple("mdf_tuple", self.field_names)
 
-    def __get__(self, obj: Optional[Advertisement], cls: Type[Advertisement])-> Optional[Union["ManufacturerDataField", Tuple, namedtuple]]:
+    def __get__(
+        self, obj: Optional[Advertisement], cls: Type[Advertisement]
+    ) -> Optional[Union["ManufacturerDataField", Tuple, namedtuple]]:
         if obj is None:
             return self
         if self._key not in obj.manufacturer_data.data:
@@ -341,7 +363,9 @@ class ServiceData(AdvertisingDataField):
 
     def __get__(
         self, obj: Optional[Service], cls: Type[Service]
-    ) -> Optional[Union["ServiceData", memoryview]]:  # pylint: disable=too-many-return-statements,too-many-branches
+    ) -> Optional[
+        Union["ServiceData", memoryview]
+    ]:  # pylint: disable=too-many-return-statements,too-many-branches
         if obj is None:
             return self
         # If not present at all and mutable, then we init it, otherwise None.

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -216,7 +216,7 @@ class ComplexCharacteristic:
 
     def __get__(
         self, service: Optional[Service], cls: Optional[Type[Service]] = None
-    ) -> Characteristic:
+    ) -> _bleio.Characteristic:
         if service is None:
             return self
         bound_object = self.bind(service)

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -8,16 +8,21 @@ This module provides core BLE characteristic classes that are used within Servic
 
 """
 
+from __future__ import annotations
+
 import struct
 import _bleio
 
 from ..attributes import Attribute
 
 try:
-    from typing import Optional, Type, Union, Tuple, Iterable
-    from circuitpython_typing import ReadableBuffer
-    from adafruit_ble.uuid import UUID
-    from adafruit_ble.services import Service
+    from typing import Optional, Type, Union, Tuple, Iterable, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer
+        from adafruit_ble.uuid import UUID
+        from adafruit_ble.services import Service
+
 except ImportError:
     pass
 
@@ -89,7 +94,7 @@ class Characteristic:
         write_perm: int = Attribute.OPEN,
         max_length: Optional[int] = None,
         fixed_length: bool = False,
-        initial_value: Optional[ReadableBuffer] = None
+        initial_value: Optional[ReadableBuffer] = None,
     ) -> None:
         self.field_name = None  # Set by Service during basic binding
 
@@ -179,7 +184,7 @@ class ComplexCharacteristic:
         write_perm: int = Attribute.OPEN,
         max_length: int = 20,
         fixed_length: bool = False,
-        initial_value: Optional[ReadableBuffer] = None
+        initial_value: Optional[ReadableBuffer] = None,
     ) -> None:
         self.field_name = None  # Set by Service during basic binding
 
@@ -240,7 +245,7 @@ class StructCharacteristic(Characteristic):
         properties: int = 0,
         read_perm: int = Attribute.OPEN,
         write_perm: int = Attribute.OPEN,
-        initial_value: Optional[ReadableBuffer] = None
+        initial_value: Optional[ReadableBuffer] = None,
     ) -> None:
         self._struct_format = struct_format
         self._expected_size = struct.calcsize(struct_format)

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -13,6 +13,14 @@ import _bleio
 
 from ..attributes import Attribute
 
+try:
+    from typing import Optional, Type, Union, Tuple, Iterable
+    from circuitpython_typing import ReadableBuffer
+    from adafruit_ble.uuid import UUID
+    from adafruit_ble.services import Service
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
@@ -75,14 +83,14 @@ class Characteristic:
     def __init__(
         self,
         *,
-        uuid=None,
-        properties=0,
-        read_perm=Attribute.OPEN,
-        write_perm=Attribute.OPEN,
-        max_length=None,
-        fixed_length=False,
-        initial_value=None
-    ):
+        uuid: Optional[UUID] = None,
+        properties: int = 0,
+        read_perm: int = Attribute.OPEN,
+        write_perm: int = Attribute.OPEN,
+        max_length: Optional[int] = None,
+        fixed_length: bool = False,
+        initial_value: Optional[ReadableBuffer] = None
+    ) -> None:
         self.field_name = None  # Set by Service during basic binding
 
         if uuid:
@@ -94,7 +102,9 @@ class Characteristic:
         self.fixed_length = fixed_length
         self.initial_value = initial_value
 
-    def _ensure_bound(self, service, initial_value=None):
+    def _ensure_bound(
+        self, service: Service, initial_value: Optional[bytes] = None
+    ) -> None:
         """Binds the characteristic to the local Service or remote Characteristic object given."""
         if self.field_name in service.bleio_characteristics:
             return
@@ -110,7 +120,9 @@ class Characteristic:
 
         service.bleio_characteristics[self.field_name] = bleio_characteristic
 
-    def __bind_locally(self, service, initial_value):
+    def __bind_locally(
+        self, service: Service, initial_value: Optional[bytes]
+    ) -> _bleio.Characteristic:
         if initial_value is None:
             initial_value = self.initial_value
         if initial_value is None and self.max_length:
@@ -132,7 +144,9 @@ class Characteristic:
             write_perm=self.write_perm,
         )
 
-    def __get__(self, service, cls=None):
+    def __get__(
+        self, service: Optional[Service], cls: Optional[Type[Service]] = None
+    ) -> ReadableBuffer:
         # CircuitPython doesn't invoke descriptor protocol on obj's class,
         # but CPython does. In the CPython case, pretend that it doesn't.
         if service is None:
@@ -141,7 +155,7 @@ class Characteristic:
         bleio_characteristic = service.bleio_characteristics[self.field_name]
         return bleio_characteristic.value
 
-    def __set__(self, service, value):
+    def __set__(self, service: Service, value: ReadableBuffer) -> None:
         self._ensure_bound(service, value)
         if value is None:
             value = b""
@@ -159,14 +173,14 @@ class ComplexCharacteristic:
     def __init__(
         self,
         *,
-        uuid=None,
-        properties=0,
-        read_perm=Attribute.OPEN,
-        write_perm=Attribute.OPEN,
-        max_length=20,
-        fixed_length=False,
-        initial_value=None
-    ):
+        uuid: Optional[UUID] = None,
+        properties: int = 0,
+        read_perm: int = Attribute.OPEN,
+        write_perm: int = Attribute.OPEN,
+        max_length: int = 20,
+        fixed_length: bool = False,
+        initial_value: Optional[ReadableBuffer] = None
+    ) -> None:
         self.field_name = None  # Set by Service during basic binding
 
         if uuid:
@@ -178,7 +192,7 @@ class ComplexCharacteristic:
         self.fixed_length = fixed_length
         self.initial_value = initial_value
 
-    def bind(self, service):
+    def bind(self, service: Service) -> _bleio.Characteristic:
         """Binds the characteristic to the local Service or remote Characteristic object given."""
         if service.remote:
             for characteristic in service.bleio_service.characteristics:
@@ -195,7 +209,9 @@ class ComplexCharacteristic:
             write_perm=self.write_perm,
         )
 
-    def __get__(self, service, cls=None):
+    def __get__(
+        self, service: Optional[Service], cls: Optional[Type[Service]] = None
+    ) -> Characteristic:
         if service is None:
             return self
         bound_object = self.bind(service)
@@ -220,12 +236,12 @@ class StructCharacteristic(Characteristic):
         self,
         struct_format,
         *,
-        uuid=None,
-        properties=0,
-        read_perm=Attribute.OPEN,
-        write_perm=Attribute.OPEN,
-        initial_value=None
-    ):
+        uuid: Optional[UUID] = None,
+        properties: int = 0,
+        read_perm: int = Attribute.OPEN,
+        write_perm: int = Attribute.OPEN,
+        initial_value: Optional[ReadableBuffer] = None
+    ) -> None:
         self._struct_format = struct_format
         self._expected_size = struct.calcsize(struct_format)
         if initial_value is not None:
@@ -240,7 +256,9 @@ class StructCharacteristic(Characteristic):
             write_perm=write_perm,
         )
 
-    def __get__(self, obj, cls=None):
+    def __get__(
+        self, obj: Optional[Service], cls: Optional[Type[Service]] = None
+    ) -> Optional[Union[Tuple, "StructCharacteristic"]]:
         if obj is None:
             return self
         raw_data = super().__get__(obj, cls)
@@ -248,6 +266,6 @@ class StructCharacteristic(Characteristic):
             return None
         return struct.unpack(self._struct_format, raw_data)
 
-    def __set__(self, obj, value):
+    def __set__(self, obj: Service, value: Iterable) -> None:
         encoded = struct.pack(self._struct_format, *value)
         super().__set__(obj, encoded)

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -10,8 +10,21 @@ This module provides float characteristics that are usable directly as attribute
 
 """
 
+from __future__ import annotations
+
 from . import Attribute
 from . import StructCharacteristic
+
+try:
+    from typing import Optional, Type, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer
+        from adafruit_ble.uuid import UUID
+        from adafruit_ble.services import Service
+
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -23,12 +36,12 @@ class FloatCharacteristic(StructCharacteristic):
     def __init__(
         self,
         *,
-        uuid=None,
-        properties=0,
-        read_perm=Attribute.OPEN,
-        write_perm=Attribute.OPEN,
-        initial_value=None
-    ):
+        uuid: Optional[UUID] = None,
+        properties: int = 0,
+        read_perm: int = Attribute.OPEN,
+        write_perm: int = Attribute.OPEN,
+        initial_value: Optional[ReadableBuffer] = None,
+    ) -> None:
         if initial_value is not None:
             initial_value = (initial_value,)
         super().__init__(
@@ -40,10 +53,12 @@ class FloatCharacteristic(StructCharacteristic):
             initial_value=initial_value,
         )
 
-    def __get__(self, obj, cls=None):
+    def __get__(
+        self, obj: Optional[Service], cls: Optional[Type[Service]] = None
+    ) -> float:
         if obj is None:
             return self
         return super().__get__(obj)[0]
 
-    def __set__(self, obj, value):
+    def __set__(self, obj: Service, value: float) -> None:
         super().__set__(obj, (value,))

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -16,7 +16,7 @@ from . import Attribute
 from . import StructCharacteristic
 
 try:
-    from typing import Optional, Type, TYPE_CHECKING
+    from typing import Optional, Type, Union, TYPE_CHECKING
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
@@ -55,7 +55,7 @@ class FloatCharacteristic(StructCharacteristic):
 
     def __get__(
         self, obj: Optional[Service], cls: Optional[Type[Service]] = None
-    ) -> float:
+    ) -> Union[float, "FloatCharacteristic"]:
         if obj is None:
             return self
         return super().__get__(obj)[0]

--- a/adafruit_ble/characteristics/int.py
+++ b/adafruit_ble/characteristics/int.py
@@ -10,8 +10,21 @@ This module provides integer characteristics that are usable directly as attribu
 
 """
 
+from __future__ import annotations
+
 from . import Attribute
 from . import StructCharacteristic
+
+try:
+    from typing import Optional, Type, Union, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer
+        from adafruit_ble.uuid import UUID
+        from adafruit_ble.services import Service
+
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -22,16 +35,16 @@ class IntCharacteristic(StructCharacteristic):
 
     def __init__(
         self,
-        format_string,
-        min_value,
-        max_value,
+        format_string: str,
+        min_value: int,
+        max_value: int,
         *,
-        uuid=None,
-        properties=0,
-        read_perm=Attribute.OPEN,
-        write_perm=Attribute.OPEN,
-        initial_value=None
-    ):
+        uuid: Optional[UUID] = None,
+        properties: int = 0,
+        read_perm: int = Attribute.OPEN,
+        write_perm: int = Attribute.OPEN,
+        initial_value: Optional[ReadableBuffer] = None,
+    ) -> None:
         self._min_value = min_value
         self._max_value = max_value
         if initial_value is not None:
@@ -48,12 +61,14 @@ class IntCharacteristic(StructCharacteristic):
             initial_value=initial_value,
         )
 
-    def __get__(self, obj, cls=None):
+    def __get__(
+        self, obj: Optional[Service], cls: Optional[Type[Service]] = None
+    ) -> Union[int, "IntCharacteristic"]:
         if obj is None:
             return self
         return super().__get__(obj)[0]
 
-    def __set__(self, obj, value):
+    def __set__(self, obj: Service, value: int) -> None:
         if not self._min_value <= value <= self._max_value:
             raise ValueError("out of range")
         super().__set__(obj, (value,))
@@ -63,7 +78,9 @@ class Int8Characteristic(IntCharacteristic):
     """Int8 number."""
 
     # pylint: disable=too-few-public-methods
-    def __init__(self, *, min_value=-128, max_value=127, **kwargs):
+    def __init__(
+        self, *, min_value: int = -128, max_value: int = 127, **kwargs
+    ) -> None:
         super().__init__("<b", min_value, max_value, **kwargs)
 
 
@@ -71,7 +88,7 @@ class Uint8Characteristic(IntCharacteristic):
     """Uint8 number."""
 
     # pylint: disable=too-few-public-methods
-    def __init__(self, *, min_value=0, max_value=0xFF, **kwargs):
+    def __init__(self, *, min_value: int = 0, max_value: int = 0xFF, **kwargs) -> None:
         super().__init__("<B", min_value, max_value, **kwargs)
 
 
@@ -79,7 +96,9 @@ class Int16Characteristic(IntCharacteristic):
     """Int16 number."""
 
     # pylint: disable=too-few-public-methods
-    def __init__(self, *, min_value=-32768, max_value=32767, **kwargs):
+    def __init__(
+        self, *, min_value: int = -32768, max_value: int = 32767, **kwargs
+    ) -> None:
         super().__init__("<h", min_value, max_value, **kwargs)
 
 
@@ -87,7 +106,9 @@ class Uint16Characteristic(IntCharacteristic):
     """Uint16 number."""
 
     # pylint: disable=too-few-public-methods
-    def __init__(self, *, min_value=0, max_value=0xFFFF, **kwargs):
+    def __init__(
+        self, *, min_value: int = 0, max_value: int = 0xFFFF, **kwargs
+    ) -> None:
         super().__init__("<H", min_value, max_value, **kwargs)
 
 
@@ -95,7 +116,9 @@ class Int32Characteristic(IntCharacteristic):
     """Int32 number."""
 
     # pylint: disable=too-few-public-methods
-    def __init__(self, *, min_value=-2147483648, max_value=2147483647, **kwargs):
+    def __init__(
+        self, *, min_value: int = -2147483648, max_value: int = 2147483647, **kwargs
+    ) -> None:
         super().__init__("<i", min_value, max_value, **kwargs)
 
 
@@ -103,5 +126,7 @@ class Uint32Characteristic(IntCharacteristic):
     """Uint32 number."""
 
     # pylint: disable=too-few-public-methods
-    def __init__(self, *, min_value=0, max_value=0xFFFFFFFF, **kwargs):
+    def __init__(
+        self, *, min_value: int = 0, max_value: int = 0xFFFFFFFF, **kwargs
+    ) -> None:
         super().__init__("<I", min_value, max_value, **kwargs)

--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -10,9 +10,22 @@ This module provides a JSON characteristic for reading/writing JSON serializable
 
 """
 
+from __future__ import annotations
+
 import json
 from . import Attribute
 from . import Characteristic
+
+try:
+    from typing import Optional, Any, Type, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer
+        from adafruit_ble.uuid import UUID
+        from adafruit_ble.services import Service
+
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -24,12 +37,12 @@ class JSONCharacteristic(Characteristic):
     def __init__(
         self,
         *,
-        uuid=None,
-        properties=Characteristic.READ,
-        read_perm=Attribute.OPEN,
-        write_perm=Attribute.OPEN,
-        initial_value=None,
-    ):
+        uuid: Optional[UUID] = None,
+        properties: int = Characteristic.READ,
+        read_perm: int = Attribute.OPEN,
+        write_perm: int = Attribute.OPEN,
+        initial_value: Optional[ReadableBuffer] = None,
+    ) -> None:
         super().__init__(
             uuid=uuid,
             properties=properties,
@@ -41,19 +54,21 @@ class JSONCharacteristic(Characteristic):
         )
 
     @staticmethod
-    def pack(value):
+    def pack(value: Any) -> bytes:
         """Converts a JSON serializable python value into a utf-8 encoded JSON string."""
         return json.dumps(value).encode("utf-8")
 
     @staticmethod
-    def unpack(value):
+    def unpack(value: ReadableBuffer) -> Any:
         """Converts a utf-8 encoded JSON string into a python value."""
         return json.loads(str(value, "utf-8"))
 
-    def __get__(self, obj, cls=None):
+    def __get__(
+        self, obj: Optional[Service], cls: Optional[Type[Service]] = None
+    ) -> Any:
         if obj is None:
             return self
         return self.unpack(super().__get__(obj, cls))
 
-    def __set__(self, obj, value):
+    def __set__(self, obj: Service, value: Any) -> None:
         super().__set__(obj, self.pack(value))

--- a/adafruit_ble/characteristics/stream.py
+++ b/adafruit_ble/characteristics/stream.py
@@ -10,11 +10,26 @@ This module provides stream characteristics that bind readable or writable objec
 object they are on.
 
 """
+
+from __future__ import annotations
+
 import _bleio
 
 from . import Attribute
 from . import Characteristic
 from . import ComplexCharacteristic
+
+try:
+    from typing import Optional, Union, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer
+        from adafruit_ble.characteristics import Characteristic
+        from adafruit_ble.uuid import UUID
+        from adafruit_ble.services import Service
+
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -23,10 +38,10 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class BoundWriteStream:
     """Writes data out to the peer."""
 
-    def __init__(self, bound_characteristic):
+    def __init__(self, bound_characteristic: Characteristic) -> None:
         self.bound_characteristic = bound_characteristic
 
-    def write(self, buf):
+    def write(self, buf: ReadableBuffer) -> None:
         """Write data from buf out to the peer."""
         # We can only write 20 bytes at a time.
         offset = 0
@@ -41,20 +56,20 @@ class StreamOut(ComplexCharacteristic):
     def __init__(
         self,
         *,
-        uuid=None,
-        timeout=1.0,
-        buffer_size=64,
-        properties=Characteristic.NOTIFY,
-        read_perm=Attribute.OPEN,
-        write_perm=Attribute.OPEN
-    ):
+        uuid: Optional[UUID] = None,
+        timeout: float = 1.0,
+        buffer_size: int = 64,
+        properties: int = Characteristic.NOTIFY,
+        read_perm: int = Attribute.OPEN,
+        write_perm: int = Attribute.OPEN,
+    ) -> None:
         self._timeout = timeout
         self._buffer_size = buffer_size
         super().__init__(
             uuid=uuid, properties=properties, read_perm=read_perm, write_perm=write_perm
         )
 
-    def bind(self, service):
+    def bind(self, service: Service) -> Union[_bleio.Characteristic, BoundWriteStream]:
         """Binds the characteristic to the given Service."""
         bound_characteristic = super().bind(service)
         # If we're given a remote service then we're the client and need to buffer in.
@@ -74,12 +89,12 @@ class StreamIn(ComplexCharacteristic):
     def __init__(
         self,
         *,
-        uuid=None,
-        timeout=1.0,
-        buffer_size=64,
-        properties=(Characteristic.WRITE | Characteristic.WRITE_NO_RESPONSE),
-        write_perm=Attribute.OPEN
-    ):
+        uuid: Optional[UUID] = None,
+        timeout: float = 1.0,
+        buffer_size: int = 64,
+        properties: int = (Characteristic.WRITE | Characteristic.WRITE_NO_RESPONSE),
+        write_perm: int = Attribute.OPEN,
+    ) -> None:
         self._timeout = timeout
         self._buffer_size = buffer_size
         super().__init__(
@@ -89,7 +104,9 @@ class StreamIn(ComplexCharacteristic):
             write_perm=write_perm,
         )
 
-    def bind(self, service):
+    def bind(
+        self, service: Service
+    ) -> Union[_bleio.CharacteristicBuffer, BoundWriteStream]:
         """Binds the characteristic to the given Service."""
         bound_characteristic = super().bind(service)
         # If the service is remote need to write out.

--- a/adafruit_ble/characteristics/string.py
+++ b/adafruit_ble/characteristics/string.py
@@ -10,8 +10,21 @@ This module provides string characteristics.
 
 """
 
+from __future__ import annotations
+
 from . import Attribute
 from . import Characteristic
+
+try:
+    from typing import Optional, Type, Union, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import ReadableBuffer
+        from adafruit_ble.uuid import UUID
+        from adafruit_ble.services import Service
+
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -23,12 +36,12 @@ class StringCharacteristic(Characteristic):
     def __init__(
         self,
         *,
-        uuid=None,
-        properties=Characteristic.READ,
-        read_perm=Attribute.OPEN,
-        write_perm=Attribute.OPEN,
-        initial_value=None
-    ):
+        uuid: Optional[UUID] = None,
+        properties: int = Characteristic.READ,
+        read_perm: int = Attribute.OPEN,
+        write_perm: int = Attribute.OPEN,
+        initial_value: Optional[ReadableBuffer] = None,
+    ) -> None:
         super().__init__(
             uuid=uuid,
             properties=properties,
@@ -39,19 +52,23 @@ class StringCharacteristic(Characteristic):
             initial_value=initial_value,
         )
 
-    def __get__(self, obj, cls=None):
+    def __get__(
+        self, obj: Optional[Service], cls: Optional[Type[Service]] = None
+    ) -> Union[str, "StringCharacteristic"]:
         if obj is None:
             return self
         return str(super().__get__(obj, cls), "utf-8")
 
-    def __set__(self, obj, value):
+    def __set__(self, obj: Service, value: str) -> None:
         super().__set__(obj, value.encode("utf-8"))
 
 
 class FixedStringCharacteristic(Characteristic):
     """Fixed strings are set once when bound and unchanged after."""
 
-    def __init__(self, *, uuid=None, read_perm=Attribute.OPEN):
+    def __init__(
+        self, *, uuid: Optional[UUID] = None, read_perm: int = Attribute.OPEN
+    ) -> None:
         super().__init__(
             uuid=uuid,
             properties=Characteristic.READ,
@@ -60,7 +77,9 @@ class FixedStringCharacteristic(Characteristic):
             fixed_length=True,
         )
 
-    def __get__(self, obj, cls=None):
+    def __get__(
+        self, obj: Service, cls: Optional[Type[Service]] = None
+    ) -> Union[str, "FixedStringCharacteristic"]:
         if obj is None:
             return self
         return str(super().__get__(obj, cls), "utf-8")

--- a/adafruit_ble/services/__init__.py
+++ b/adafruit_ble/services/__init__.py
@@ -8,9 +8,16 @@ This module provides the top level Service definition.
 
 """
 
+from __future__ import annotations
+
 import _bleio
 
 from ..characteristics import Characteristic, ComplexCharacteristic
+
+try:
+    from typing import Optional
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -29,7 +36,13 @@ class Service:
     instance for the connection's peer.
     """
 
-    def __init__(self, *, service=None, secondary=False, **initial_values):
+    def __init__(
+        self,
+        *,
+        service: Optional[_bleio.Service] = None,
+        secondary: bool = False,
+        **initial_values,
+    ) -> None:
         if service is None:
             # pylint: disable=no-member
             self.bleio_service = _bleio.Service(
@@ -70,6 +83,6 @@ class Service:
                     getattr(self, class_attr)
 
     @property
-    def remote(self):
+    def remote(self) -> bool:
         """True if the service is provided by a peer and accessed remotely."""
         return self.bleio_service.remote

--- a/adafruit_ble/services/circuitpython.py
+++ b/adafruit_ble/services/circuitpython.py
@@ -23,7 +23,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class CircuitPythonUUID(VendorUUID):
     """UUIDs with the CircuitPython base UUID."""
 
-    def __init__(self, uuid16):
+    def __init__(self, uuid16: int) -> None:
         uuid128 = bytearray("nhtyPtiucriC".encode("utf-8") + b"\x00\x00\xaf\xad")
         uuid128[-3] = uuid16 >> 8
         uuid128[-4] = uuid16 & 0xFF

--- a/adafruit_ble/services/midi.py
+++ b/adafruit_ble/services/midi.py
@@ -14,6 +14,11 @@ from . import Service
 from ..uuid import VendorUUID
 from ..characteristics import Characteristic
 
+try:
+    from typing import Optional
+except ImportError:
+    pass
+
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
@@ -24,7 +29,7 @@ class MidiIOCharacteristic(Characteristic):
     # pylint: disable=too-few-public-methods
     uuid = VendorUUID("7772E5DB-3868-4112-A1A9-F2669D106BF3")
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__(
             properties=(
                 Characteristic.NOTIFY
@@ -43,7 +48,7 @@ class MidiService(Service):
     io = MidiIOCharacteristic()  # pylint: disable=invalid-name
 
     # pylint: disable=unnecessary-pass
-    def write(self):
+    def write(self) -> None:
         """Placeholder for transmitting midi bytes to the other device."""
         pass
         # add timestamp to writes 13-bit millisecond resolution
@@ -59,6 +64,6 @@ class MidiService(Service):
         # high timestamp header byte. Low timestamp packets may wrap around and the decoder is
         # responsible for incrementing the high bits
 
-    def read(self):
+    def read(self) -> None:
         """Placeholder for receiving midi bytes from the other device."""
         pass

--- a/adafruit_ble/services/midi.py
+++ b/adafruit_ble/services/midi.py
@@ -14,11 +14,6 @@ from . import Service
 from ..uuid import VendorUUID
 from ..characteristics import Characteristic
 
-try:
-    from typing import Optional
-except ImportError:
-    pass
-
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 

--- a/adafruit_ble/services/nordic.py
+++ b/adafruit_ble/services/nordic.py
@@ -11,9 +11,21 @@ This module provides Services used by Nordic Semiconductors.
 
 """
 
+from __future__ import annotations
+
 from . import Service
 from ..uuid import VendorUUID
 from ..characteristics.stream import StreamOut, StreamIn
+
+try:
+    from typing import Optional, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from circuitpython_typing import WriteableBuffer, ReadableBuffer
+        import _bleio
+
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -39,7 +51,7 @@ class UARTService(Service):
         buffer_size=64,
     )
 
-    def __init__(self, service=None):
+    def __init__(self, service: Optional[_bleio.Service] = None) -> None:
         super().__init__(service=service)
         self.connectable = True
         if not service:
@@ -50,7 +62,7 @@ class UARTService(Service):
             self._tx = self._server_rx
             self._rx = self._server_tx
 
-    def read(self, nbytes=None):
+    def read(self, nbytes: Optional[int] = None) -> Optional[bytes]:
         """
         Read characters. If ``nbytes`` is specified then read at most that many bytes.
         Otherwise, read everything that arrives until the connection times out.
@@ -61,7 +73,9 @@ class UARTService(Service):
         """
         return self._rx.read(nbytes)
 
-    def readinto(self, buf, nbytes=None):
+    def readinto(
+        self, buf: WriteableBuffer, nbytes: Optional[int] = None
+    ) -> Optional[int]:
         """
         Read bytes into the ``buf``. If ``nbytes`` is specified then read at most
         that many bytes. Otherwise, read at most ``len(buf)`` bytes.
@@ -71,7 +85,7 @@ class UARTService(Service):
         """
         return self._rx.readinto(buf, nbytes)
 
-    def readline(self):
+    def readline(self) -> Optional[bytes]:
         """
         Read a line, ending in a newline character.
 
@@ -81,14 +95,14 @@ class UARTService(Service):
         return self._rx.readline()
 
     @property
-    def in_waiting(self):
+    def in_waiting(self) -> int:
         """The number of bytes in the input buffer, available to be read."""
         return self._rx.in_waiting
 
-    def reset_input_buffer(self):
+    def reset_input_buffer(self) -> None:
         """Discard any unread characters in the input buffer."""
         self._rx.reset_input_buffer()
 
-    def write(self, buf):
+    def write(self, buf: ReadableBuffer) -> None:
         """Write a buffer of bytes."""
         self._tx.write(buf)

--- a/adafruit_ble/services/standard/__init__.py
+++ b/adafruit_ble/services/standard/__init__.py
@@ -8,6 +8,8 @@ This module provides Service classes for BLE defined standard services.
 
 """
 
+from __future__ import annotations
+
 import time
 
 from .. import Service

--- a/adafruit_ble/services/standard/__init__.py
+++ b/adafruit_ble/services/standard/__init__.py
@@ -27,7 +27,7 @@ class AppearanceCharacteristic(StructCharacteristic):
     # pylint: disable=too-few-public-methods
     uuid = StandardUUID(0x2A01)
 
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs) -> None:
         super().__init__("<H", **kwargs)
 
 
@@ -72,7 +72,7 @@ class CurrentTimeService(Service):
     """A tuple of location information: (timezone, dst_offset)"""
 
     @property
-    def struct_time(self):
+    def struct_time(self) -> time.struct_time:
         """The current time as a `time.struct_time`. Day of year and whether DST is in effect
         are always -1.
         """

--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -9,6 +9,8 @@
 
 """
 
+from __future__ import annotations
+
 import binascii
 import os
 import sys
@@ -16,6 +18,15 @@ import sys
 from .. import Service
 from ...uuid import StandardUUID
 from ...characteristics.string import FixedStringCharacteristic
+
+try:
+    from typing import Optional, TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        import _bleio
+
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -35,14 +46,14 @@ class DeviceInfoService(Service):
     def __init__(
         self,
         *,
-        manufacturer=None,
-        software_revision=None,
-        model_number=None,
-        serial_number=None,
-        firmware_revision=None,
-        hardware_revision=None,
-        service=None
-    ):
+        manufacturer: Optional[str] = None,
+        software_revision: Optional[str] = None,
+        model_number: Optional[str] = None,
+        serial_number: Optional[str] = None,
+        firmware_revision: Optional[str] = None,
+        hardware_revision: Optional[str] = None,
+        service: Optional[_bleio.Service] = None,
+    ) -> None:
         if not service:
             if model_number is None:
                 model_number = sys.platform

--- a/adafruit_ble/services/standard/hid.py
+++ b/adafruit_ble/services/standard/hid.py
@@ -11,6 +11,9 @@ BLE Human Interface Device (HID)
 * Author(s): Dan Halbert for Adafruit Industries
 
 """
+
+from __future__ import annotations
+
 import struct
 
 from micropython import const
@@ -22,6 +25,11 @@ from adafruit_ble.characteristics.int import Uint8Characteristic
 from adafruit_ble.uuid import StandardUUID
 
 from .. import Service
+
+try:
+    from typing import Dict, Optional
+except ImportError:
+    pass
 
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -165,7 +173,15 @@ class ReportIn:
 
     uuid = StandardUUID(_REPORT_UUID_NUM)
 
-    def __init__(self, service, report_id, usage_page, usage, *, max_length):
+    def __init__(
+        self,
+        service: Service,
+        report_id: int,
+        usage_page: bytes,
+        usage: bytes,
+        *,
+        max_length: int,
+    ) -> None:
         self._characteristic = _bleio.Characteristic.add_to_service(
             service.bleio_service,
             self.uuid.bleio_uuid,
@@ -187,7 +203,7 @@ class ReportIn:
             initial_value=struct.pack("<BB", self._report_id, _REPORT_TYPE_INPUT),
         )
 
-    def send_report(self, report):
+    def send_report(self, report: Dict) -> None:
         """Send a report to the peers"""
         self._characteristic.value = report
 
@@ -198,7 +214,15 @@ class ReportOut:
     # pylint: disable=too-few-public-methods
     uuid = StandardUUID(_REPORT_UUID_NUM)
 
-    def __init__(self, service, report_id, usage_page, usage, *, max_length):
+    def __init__(
+        self,
+        service: Service,
+        report_id: int,
+        usage_page: bytes,
+        usage: bytes,
+        *,
+        max_length: int,
+    ) -> None:
         self._characteristic = _bleio.Characteristic.add_to_service(
             service.bleio_service,
             self.uuid.bleio_uuid,
@@ -225,7 +249,7 @@ class ReportOut:
         )
 
     @property
-    def report(self):
+    def report(self) -> Dict:
         """The HID OUT report"""
         return self._characteristic.value
 
@@ -320,14 +344,18 @@ class HIDService(Service):
     )
     """Controls whether the device should be suspended (0) or not (1)."""
 
-    def __init__(self, hid_descriptor=DEFAULT_HID_DESCRIPTOR, service=None):
+    def __init__(
+        self,
+        hid_descriptor: bytes = DEFAULT_HID_DESCRIPTOR,
+        service: Optional[Service] = None,
+    ) -> None:
         super().__init__(report_map=hid_descriptor)
         if service:
             # TODO: Add support for connecting to a remote hid server.
             pass
         self._init_devices()
 
-    def _init_devices(self):
+    def _init_devices(self) -> None:
         # pylint: disable=too-many-branches,too-many-statements,too-many-locals
         self.devices = []
         hid_descriptor = self.report_map
@@ -389,7 +417,7 @@ class HIDService(Service):
 
             i += size
 
-        def get_report_info(collection, reports):
+        def get_report_info(collection: Dict, reports: Dict) -> None:
             """Gets info about hid reports"""
             for main in collection["mains"]:
                 if "type" in main:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@
 
 Adafruit-Blinka
 adafruit-blinka-bleio
+adafruit-circuitpython-typing
+typing-extensions~=4.0.0


### PR DESCRIPTION
The Big One!  Resolves #137 by adding type annotations for this library.

Notes:
- Lines of similarity needed to be increased to avoid refactoring.
- Using a combination of `from __futures__ import annotations` and `if typing.TYPE_CHECKING` to avoid circular imports and unbound types.