### PR TITLE
Increase default connect timeout to 10 seconds

### DIFF
--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -297,7 +297,7 @@ class BLERadio:
         self._adapter.stop_scan()
 
     def connect(
-        self, peer: Union[Advertisement, _bleio.Address], *, timeout: float = 4.0
+        self, peer: Union[Advertisement, _bleio.Address], *, timeout: float = 10.0
     ) -> BLEConnection:
         """
         Initiates a `BLEConnection` to the peer that advertised the given advertisement.


### PR DESCRIPTION
4 seconds, the previous default connect timeout, was too short sometimes, when testing blinka_bleio with `bleak 0.20.1`. See https://github.com/adafruit/Adafruit_Blinka_bleio/pull/58#issue-1651163274