### PR TITLE
Deinit UARTService CharacteristicBuffers on disconnect

### DIFF
--- a/adafruit_ble/__init__.py
+++ b/adafruit_ble/__init__.py
@@ -145,6 +145,9 @@ class BLEConnection:
     def disconnect(self) -> None:
         """Disconnect from peer."""
         self._bleio_connection.disconnect()
+        # Clean up any services that need explicit cleanup.
+        for service in self._constructed_services.values():
+            service.deinit()
 
 
 class BLERadio:

--- a/adafruit_ble/characteristics/stream.py
+++ b/adafruit_ble/characteristics/stream.py
@@ -69,7 +69,9 @@ class StreamOut(ComplexCharacteristic):
             uuid=uuid, properties=properties, read_perm=read_perm, write_perm=write_perm
         )
 
-    def bind(self, service: Service) -> Union[_bleio.Characteristic, BoundWriteStream]:
+    def bind(
+        self, service: Service
+    ) -> Union[_bleio.CharacteristicBuffer, BoundWriteStream]:
         """Binds the characteristic to the given Service."""
         bound_characteristic = super().bind(service)
         # If we're given a remote service then we're the client and need to buffer in.

--- a/adafruit_ble/services/__init__.py
+++ b/adafruit_ble/services/__init__.py
@@ -82,6 +82,9 @@ class Service:
                 else:
                     getattr(self, class_attr)
 
+    def deinit(self):
+        """Override this method to do any explicit cleanup necessary on connection close."""
+
     @property
     def remote(self) -> bool:
         """True if the service is provided by a peer and accessed remotely."""

--- a/adafruit_ble/services/nordic.py
+++ b/adafruit_ble/services/nordic.py
@@ -62,6 +62,14 @@ class UARTService(Service):
             self._tx = self._server_rx
             self._rx = self._server_tx
 
+    def deinit(self):
+        """The characteristic buffers must be deinitialized when no longer needed.
+        Otherwise they will leak storage.
+        """
+        for obj in (self._tx, self._rx):
+            if hasattr(obj, "deinit"):
+                obj.deinit()
+
     def read(self, nbytes: Optional[int] = None) -> Optional[bytes]:
         """
         Read characters. If ``nbytes`` is specified then read at most that many bytes.


### PR DESCRIPTION
- Fixes #192.

`CharacteristicBuffer` must be `deinit'd` after use, to prevent a storage leak. Do this for UARTService, and provide a mechanism to invoke `deinit()` on `disconnect()`.

test to detect storage leak:
```py
import os, gc
import time
import board
from adafruit_ble import BLERadio
from adafruit_ble.services.nordic import UARTService
from adafruit_ble.advertising.standard import ProvideServicesAdvertisement

ble = BLERadio()
uart = UARTService()

while True:
    print("Scanning ...")
    for adv in ble.start_scan(ProvideServicesAdvertisement, timeout=1):
        if UARTService not in adv.services:
            continue
        count = 1
        while True:
            try:
                conn = ble.connect(adv)
                svc = conn[UARTService]
                print(f"{count} Free memory: {gc.mem_free()}, Allocated memory: {gc.mem_alloc()}")
                conn.disconnect()
                conn = None
                svc = None
                gc.collect()
            except Exception as e:
                print("Error: ", e)
            count += 1
```