### PR TITLE
typing overhaul + pre-commit updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,7 @@ repos:
         files: "^tests/"
         args:
           - --disable=missing-docstring,consider-using-f-string,duplicate-code
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.0
+    hooks:
+      - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files"]
   - repo: https://github.com/fsfe/reuse-tool
     rev: v1.1.2
     hooks:
@@ -18,7 +23,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+    rev: v3.0.4
     hooks:
       - id: pylint
         name: pylint (library code)

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -11,17 +11,7 @@ from __future__ import annotations
 import struct
 
 try:
-    from typing import (
-        TYPE_CHECKING,
-        Any,
-        Dict,
-        List,
-        Optional,
-        Tuple,
-        Type,
-        TypeVar,
-        Union,
-    )
+    from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, Type, TypeVar, Union
 
     from typing_extensions import Literal
 
@@ -245,6 +235,7 @@ class Advertisement:
 
     address: Optional[Address]
     _rssi: Optional[int]
+    mutable: bool
 
     match_prefixes: Optional[Tuple[bytes, ...]] = ()
     """For Advertisement, :py:attr:`~adafruit_ble.advertising.Advertisement.match_prefixes`

--- a/adafruit_ble/advertising/__init__.py
+++ b/adafruit_ble/advertising/__init__.py
@@ -147,8 +147,7 @@ class AdvertisingFlags(AdvertisingDataField):
         self.flags = 0
         if self._adt in self._advertisement.data_dict:
             value = self._advertisement.data_dict[self._adt]
-            if isinstance(value, list):
-                raise RuntimeError
+            assert not isinstance(value, list)
             self.flags = value[0]
 
     def __len__(self) -> Literal[1]:
@@ -183,8 +182,7 @@ class String(AdvertisingDataField):
         if self._adt not in obj.data_dict:
             return None
         value = obj.data_dict[self._adt]
-        if isinstance(value, list):
-            raise RuntimeError
+        assert not isinstance(value, list)
         return str(value, "utf-8")
 
     def __set__(self, obj: "Advertisement", value: str) -> None:
@@ -206,8 +204,7 @@ class Struct(AdvertisingDataField):
         if self._adt not in obj.data_dict:
             return None
         value = obj.data_dict[self._adt]
-        if isinstance(value, list):
-            raise RuntimeError
+        assert not isinstance(value, list)
         return struct.unpack(self._format, value)[0]
 
     def __set__(self, obj: "Advertisement", value: Any) -> None:
@@ -254,6 +251,9 @@ class Advertisement:
     The class attribute ``match_prefixes``, if not ``None``, is a tuple of
     bytestring prefixes to match against the multiple data structures in the advertisement.
     """
+
+    address: Optional[Address]
+    _rssi: Optional[int]
 
     match_prefixes: Optional[Tuple[bytes, ...]] = ()
     """For Advertisement, :py:attr:`~adafruit_ble.advertising.Advertisement.match_prefixes`

--- a/adafruit_ble/advertising/adafruit.py
+++ b/adafruit_ble/advertising/adafruit.py
@@ -15,6 +15,7 @@ Adafruit customers for their own data.
 """
 
 import struct
+
 from micropython import const
 
 from . import Advertisement, LazyObjectField

--- a/adafruit_ble/advertising/standard.py
+++ b/adafruit_ble/advertising/standard.py
@@ -11,24 +11,38 @@ even though multiple purposes may actually be present in a single packet.
 
 """
 
+from __future__ import annotations
+
 import struct
 from collections import OrderedDict, namedtuple
 
+from ..uuid import StandardUUID, VendorUUID
 from . import (
     Advertisement,
     AdvertisingDataField,
-    encode_data,
-    decode_data,
-    to_hex,
     compute_length,
+    decode_data,
+    encode_data,
+    to_hex,
 )
-from ..uuid import StandardUUID, VendorUUID
 
 try:
-    from typing import Optional, List, Tuple, Union, Type, Iterator, Iterable, Any
-    from adafruit_ble.uuid import UUID
-    from adafruit_ble.services import Service
+    from typing import (
+        Any,
+        Collection,
+        Iterable,
+        Iterator,
+        List,
+        Optional,
+        Tuple,
+        Type,
+        Union,
+    )
+
     from _bleio import ScanEntry
+
+    from adafruit_ble.services import Service
+    from adafruit_ble.uuid import UUID
 
     UsesServicesAdvertisement = Union[
         "ProvideServicesAdvertisement", "SolicitServicesAdvertisement"
@@ -50,7 +64,7 @@ class BoundServiceList:
         advertisement: UsesServicesAdvertisement,
         *,
         standard_services: List[int],
-        vendor_services: List[int]
+        vendor_services: List[int],
     ) -> None:
         self._advertisement = advertisement
         self._standard_service_fields = standard_services
@@ -243,7 +257,7 @@ class ManufacturerData(AdvertisingDataField):
         *,
         advertising_data_type: int = 0xFF,
         company_id: int,
-        key_encoding: str = "B"
+        key_encoding: str = "B",
     ) -> None:
         self._obj = obj
         self._company_id = company_id
@@ -281,7 +295,7 @@ class ManufacturerDataField:
     """A single piece of data within the manufacturer specific data. The format can be repeated."""
 
     def __init__(
-        self, key: int, value_format: str, field_names: Optional[Iterable[str]] = None
+        self, key: int, value_format: str, field_names: Optional[Collection[str]] = None
     ) -> None:
         self._key = key
         self._format = value_format
@@ -302,7 +316,7 @@ class ManufacturerDataField:
 
     def __get__(
         self, obj: Optional[Advertisement], cls: Type[Advertisement]
-    ) -> Optional[Union["ManufacturerDataField", Tuple, namedtuple]]:
+    ) -> Optional[Union["ManufacturerDataField", Tuple, tuple]]:
         if obj is None:
             return self
         if self._key not in obj.manufacturer_data.data:

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -16,6 +16,7 @@ import _bleio
 
 from ..attributes import Attribute
 
+TYPE_CHECKING = False
 try:
     from typing import TYPE_CHECKING, Iterable, Optional, Tuple, Type, Union, overload
 

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -23,7 +23,9 @@ try:
         from circuitpython_typing import ReadableBuffer
 
         from adafruit_ble.services import Service
-        from adafruit_ble.uuid import UUID
+        from adafruit_ble.uuid import StandardUUID, VendorUUID
+
+        Uuid = Union[StandardUUID, VendorUUID]
 
 except ImportError:
     pass
@@ -93,7 +95,7 @@ class Characteristic:
     def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         properties: int = 0,
         read_perm: int = Attribute.OPEN,
         write_perm: int = Attribute.OPEN,
@@ -199,7 +201,7 @@ class ComplexCharacteristic:
     def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         properties: int = 0,
         read_perm: int = Attribute.OPEN,
         write_perm: int = Attribute.OPEN,
@@ -276,7 +278,7 @@ class StructCharacteristic(Characteristic):
         self,
         struct_format,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         properties: int = 0,
         read_perm: int = Attribute.OPEN,
         write_perm: int = Attribute.OPEN,

--- a/adafruit_ble/characteristics/__init__.py
+++ b/adafruit_ble/characteristics/__init__.py
@@ -11,17 +11,19 @@ This module provides core BLE characteristic classes that are used within Servic
 from __future__ import annotations
 
 import struct
+
 import _bleio
 
 from ..attributes import Attribute
 
 try:
-    from typing import Optional, Type, Union, Tuple, Iterable, TYPE_CHECKING
+    from typing import TYPE_CHECKING, Iterable, Optional, Tuple, Type, Union, overload
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
-        from adafruit_ble.uuid import UUID
+
         from adafruit_ble.services import Service
+        from adafruit_ble.uuid import UUID
 
 except ImportError:
     pass
@@ -32,7 +34,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 
 class Characteristic:
     """
-    Top level Characteristic class that does basic binding.
+    Base Characteristic class that does basic binding.
 
     :param UUID uuid: The uuid of the characteristic
     :param int properties: The properties of the characteristic,
@@ -85,7 +87,10 @@ class Characteristic:
     WRITE = _bleio.Characteristic.WRITE
     WRITE_NO_RESPONSE = _bleio.Characteristic.WRITE_NO_RESPONSE
 
-    def __init__(
+    field_name: str
+    value: ReadableBuffer
+
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         uuid: Optional[UUID] = None,
@@ -96,7 +101,7 @@ class Characteristic:
         fixed_length: bool = False,
         initial_value: Optional[ReadableBuffer] = None,
     ) -> None:
-        self.field_name = None  # Set by Service during basic binding
+        # field_name is set by Service during basic binding
 
         if uuid:
             self.uuid = uuid
@@ -126,18 +131,18 @@ class Characteristic:
         service.bleio_characteristics[self.field_name] = bleio_characteristic
 
     def __bind_locally(
-        self, service: Service, initial_value: Optional[bytes]
+        self, service: Service, initial_value: Optional[ReadableBuffer]
     ) -> _bleio.Characteristic:
-        if initial_value is None:
-            initial_value = self.initial_value
-        if initial_value is None and self.max_length:
-            initial_value = bytes(self.max_length)
+        value = initial_value if initial_value is not None else self.initial_value
+
         max_length = self.max_length
-        if max_length is None and initial_value is None:
-            max_length = 0
-            initial_value = b""
-        elif max_length is None:
-            max_length = len(initial_value)
+        if value is None:
+            if max_length is None:
+                max_length = 0
+                value = b""
+        else:
+            max_length = len(value)
+
         return _bleio.Characteristic.add_to_service(
             service.bleio_service,
             self.uuid.bleio_uuid,
@@ -149,9 +154,23 @@ class Characteristic:
             write_perm=self.write_perm,
         )
 
+    if TYPE_CHECKING:
+
+        @overload
+        def __get__(
+            self, service: None, cls: Optional[Type[Service]] = None
+        ) -> Characteristic:
+            ...
+
+        @overload
+        def __get__(
+            self, service: Service, cls: Optional[Type[Service]] = None
+        ) -> ReadableBuffer:
+            ...
+
     def __get__(
         self, service: Optional[Service], cls: Optional[Type[Service]] = None
-    ) -> ReadableBuffer:
+    ) -> Union[Characteristic, ReadableBuffer]:
         # CircuitPython doesn't invoke descriptor protocol on obj's class,
         # but CPython does. In the CPython case, pretend that it doesn't.
         if service is None:
@@ -175,7 +194,9 @@ class ComplexCharacteristic:
     has been bound to the corresponding instance attribute.
     """
 
-    def __init__(
+    field_name: str
+
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         uuid: Optional[UUID] = None,
@@ -186,7 +207,7 @@ class ComplexCharacteristic:
         fixed_length: bool = False,
         initial_value: Optional[ReadableBuffer] = None,
     ) -> None:
-        self.field_name = None  # Set by Service during basic binding
+        # field_name is set by Service during basic binding
 
         if uuid:
             self.uuid = uuid
@@ -214,9 +235,23 @@ class ComplexCharacteristic:
             write_perm=self.write_perm,
         )
 
+    if TYPE_CHECKING:
+
+        @overload
+        def __get__(
+            self, service: None, cls: Optional[Type[Service]] = None
+        ) -> ComplexCharacteristic:
+            ...
+
+        @overload
+        def __get__(
+            self, service: Service, cls: Optional[Type[Service]] = None
+        ) -> _bleio.Characteristic:
+            ...
+
     def __get__(
         self, service: Optional[Service], cls: Optional[Type[Service]] = None
-    ) -> _bleio.Characteristic:
+    ) -> Union[ComplexCharacteristic, _bleio.Characteristic]:
         if service is None:
             return self
         bound_object = self.bind(service)
@@ -237,7 +272,7 @@ class StructCharacteristic(Characteristic):
     :param buf initial_value: see `Characteristic`
     """
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         struct_format,
         *,
@@ -261,9 +296,26 @@ class StructCharacteristic(Characteristic):
             write_perm=write_perm,
         )
 
+    if TYPE_CHECKING:
+
+        @overload
+        def __get__(
+            self, obj: None, cls: Optional[Type[Service]] = None
+        ) -> Characteristic:
+            # NOTE(elpekenin): we actually return StructCharacteristic, but we hint like
+            # this so that we dont change parent's function signature, causing a mypy warn
+            # regardless, this is not wrong, just incomplete, because this is a subclass
+            ...
+
+        @overload
+        def __get__(
+            self, obj: Service, cls: Optional[Type[Service]] = None
+        ) -> Optional[Tuple[int, ...]]:
+            ...
+
     def __get__(
         self, obj: Optional[Service], cls: Optional[Type[Service]] = None
-    ) -> Optional[Union[Tuple, "StructCharacteristic"]]:
+    ) -> Union[Characteristic, Optional[Tuple[int, ...]]]:
         if obj is None:
             return self
         raw_data = super().__get__(obj, cls)

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -76,8 +76,7 @@ class FloatCharacteristic(StructCharacteristic):
         if obj is None:
             return self
         get = super().__get__(obj)
-        if get is None:
-            raise RuntimeError
+        assert get is not None
         return get[0]  # pylint: disable=unsubscriptable-object
 
     def __set__(self, obj: Service, value: float) -> None:  # type: ignore[override]

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -12,16 +12,17 @@ This module provides float characteristics that are usable directly as attribute
 
 from __future__ import annotations
 
-from . import Attribute
-from . import StructCharacteristic
+from . import Attribute, StructCharacteristic
 
 try:
-    from typing import Optional, Type, Union, TYPE_CHECKING
+    from typing import TYPE_CHECKING, Optional, Type, Union, overload
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
-        from adafruit_ble.uuid import UUID
+
+        from adafruit_ble.characteristics import Characteristic
         from adafruit_ble.services import Service
+        from adafruit_ble.uuid import UUID
 
 except ImportError:
     pass
@@ -33,7 +34,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class FloatCharacteristic(StructCharacteristic):
     """32-bit float"""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         uuid: Optional[UUID] = None,
@@ -53,12 +54,28 @@ class FloatCharacteristic(StructCharacteristic):
             initial_value=initial_value,
         )
 
+    if TYPE_CHECKING:
+
+        @overload
+        def __get__(
+            self, obj: None, cls: Optional[Type[Service]] = None
+        ) -> Characteristic:
+            ...
+
+        @overload
+        def __get__(self, obj: Service, cls: Optional[Type[Service]] = None) -> float:
+            ...
+
     def __get__(
         self, obj: Optional[Service], cls: Optional[Type[Service]] = None
-    ) -> Union[float, "FloatCharacteristic"]:
+    ) -> Union[Characteristic, float]:
         if obj is None:
             return self
-        return super().__get__(obj)[0]
+        get = super().__get__(obj)
+        if get is None:
+            msg = "Unreachable?"
+            raise RuntimeError(msg)
+        return get[0]  # pylint: disable=unsubscriptable-object
 
     def __set__(self, obj: Service, value: float) -> None:
         super().__set__(obj, (value,))

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from . import Attribute, StructCharacteristic
 
+TYPE_CHECKING = False
 try:
     from typing import TYPE_CHECKING, Optional, Type, Union, overload
 
@@ -57,8 +58,9 @@ class FloatCharacteristic(StructCharacteristic):
         )
 
     if TYPE_CHECKING:
-
-        @overload
+        # NOTE(elpekenin): return type doesn't match parent, but that's
+        # not a problem
+        @overload  # type: ignore[override]
         def __get__(
             self, obj: None, cls: Optional[Type[Service]] = None
         ) -> Characteristic:
@@ -75,9 +77,8 @@ class FloatCharacteristic(StructCharacteristic):
             return self
         get = super().__get__(obj)
         if get is None:
-            msg = "Unreachable?"
-            raise RuntimeError(msg)
+            raise RuntimeError
         return get[0]  # pylint: disable=unsubscriptable-object
 
-    def __set__(self, obj: Service, value: float) -> None:
+    def __set__(self, obj: Service, value: float) -> None:  # type: ignore[override]
         super().__set__(obj, (value,))

--- a/adafruit_ble/characteristics/float.py
+++ b/adafruit_ble/characteristics/float.py
@@ -22,7 +22,9 @@ try:
 
         from adafruit_ble.characteristics import Characteristic
         from adafruit_ble.services import Service
-        from adafruit_ble.uuid import UUID
+        from adafruit_ble.uuid import StandardUUID, VendorUUID
+
+        Uuid = Union[StandardUUID, VendorUUID]
 
 except ImportError:
     pass
@@ -37,7 +39,7 @@ class FloatCharacteristic(StructCharacteristic):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         properties: int = 0,
         read_perm: int = Attribute.OPEN,
         write_perm: int = Attribute.OPEN,

--- a/adafruit_ble/characteristics/int.py
+++ b/adafruit_ble/characteristics/int.py
@@ -22,7 +22,9 @@ try:
 
         from adafruit_ble.characteristics import Characteristic
         from adafruit_ble.services import Service
-        from adafruit_ble.uuid import UUID
+        from adafruit_ble.uuid import StandardUUID, VendorUUID
+
+        Uuid = Union[StandardUUID, VendorUUID]
 
 except ImportError:
     pass
@@ -40,7 +42,7 @@ class IntCharacteristic(StructCharacteristic):
         min_value: int,
         max_value: int,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         properties: int = 0,
         read_perm: int = Attribute.OPEN,
         write_perm: int = Attribute.OPEN,

--- a/adafruit_ble/characteristics/int.py
+++ b/adafruit_ble/characteristics/int.py
@@ -84,8 +84,7 @@ class IntCharacteristic(StructCharacteristic):
         if obj is None:
             return self
         get = super().__get__(obj)
-        if get is None:
-            raise RuntimeError
+        assert get is not None
         return get[0]  # pylint: disable=unsubscriptable-object
 
     def __set__(self, obj: Service, value: int) -> None:  # type: ignore[override]

--- a/adafruit_ble/characteristics/int.py
+++ b/adafruit_ble/characteristics/int.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from . import Attribute, StructCharacteristic
 
+TYPE_CHECKING = False
 try:
     from typing import TYPE_CHECKING, Optional, Type, Union, overload
 
@@ -65,8 +66,9 @@ class IntCharacteristic(StructCharacteristic):
         )
 
     if TYPE_CHECKING:
-
-        @overload
+        # NOTE(elpekenin): return type doesn't match parent, but that's
+        # not a problem
+        @overload  # type: ignore[override]
         def __get__(
             self, obj: None, cls: Optional[Type[Service]] = None
         ) -> Characteristic:
@@ -83,11 +85,10 @@ class IntCharacteristic(StructCharacteristic):
             return self
         get = super().__get__(obj)
         if get is None:
-            msg = "Unreachable?"
-            raise RuntimeError(msg)
+            raise RuntimeError
         return get[0]  # pylint: disable=unsubscriptable-object
 
-    def __set__(self, obj: Service, value: int) -> None:
+    def __set__(self, obj: Service, value: int) -> None:  # type: ignore[override]
         if not self._min_value <= value <= self._max_value:
             raise ValueError("out of range")
         super().__set__(obj, (value,))

--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -13,16 +13,17 @@ This module provides a JSON characteristic for reading/writing JSON serializable
 from __future__ import annotations
 
 import json
-from . import Attribute
-from . import Characteristic
+
+from . import Attribute, Characteristic
 
 try:
-    from typing import Optional, Any, Type, TYPE_CHECKING
+    from typing import TYPE_CHECKING, Any, Optional, Type
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
-        from adafruit_ble.uuid import UUID
+
         from adafruit_ble.services import Service
+        from adafruit_ble.uuid import UUID
 
 except ImportError:
     pass
@@ -34,7 +35,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class JSONCharacteristic(Characteristic):
     """JSON string characteristic for JSON serializable values of a limited size (max_length)."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         uuid: Optional[UUID] = None,

--- a/adafruit_ble/characteristics/json.py
+++ b/adafruit_ble/characteristics/json.py
@@ -17,13 +17,15 @@ import json
 from . import Attribute, Characteristic
 
 try:
-    from typing import TYPE_CHECKING, Any, Optional, Type
+    from typing import TYPE_CHECKING, Any, Optional, Type, Union
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
 
         from adafruit_ble.services import Service
-        from adafruit_ble.uuid import UUID
+        from adafruit_ble.uuid import StandardUUID, VendorUUID
+
+        Uuid = Union[StandardUUID, VendorUUID]
 
 except ImportError:
     pass
@@ -38,7 +40,7 @@ class JSONCharacteristic(Characteristic):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         properties: int = Characteristic.READ,
         read_perm: int = Attribute.OPEN,
         write_perm: int = Attribute.OPEN,

--- a/adafruit_ble/characteristics/stream.py
+++ b/adafruit_ble/characteristics/stream.py
@@ -25,7 +25,9 @@ try:
 
         from adafruit_ble.characteristics import Characteristic
         from adafruit_ble.services import Service
-        from adafruit_ble.uuid import UUID
+        from adafruit_ble.uuid import StandardUUID, VendorUUID
+
+        Uuid = Union[StandardUUID, VendorUUID]
 
 except ImportError:
     pass
@@ -55,7 +57,7 @@ class StreamOut(ComplexCharacteristic):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         timeout: float = 1.0,
         buffer_size: int = 64,
         properties: int = Characteristic.NOTIFY,
@@ -90,7 +92,7 @@ class StreamIn(ComplexCharacteristic):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         timeout: float = 1.0,
         buffer_size: int = 64,
         properties: int = (Characteristic.WRITE | Characteristic.WRITE_NO_RESPONSE),

--- a/adafruit_ble/characteristics/stream.py
+++ b/adafruit_ble/characteristics/stream.py
@@ -15,18 +15,17 @@ from __future__ import annotations
 
 import _bleio
 
-from . import Attribute
-from . import Characteristic
-from . import ComplexCharacteristic
+from . import Attribute, Characteristic, ComplexCharacteristic
 
 try:
-    from typing import Optional, Union, TYPE_CHECKING
+    from typing import TYPE_CHECKING, Optional, Union
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
+
         from adafruit_ble.characteristics import Characteristic
-        from adafruit_ble.uuid import UUID
         from adafruit_ble.services import Service
+        from adafruit_ble.uuid import UUID
 
 except ImportError:
     pass
@@ -53,7 +52,7 @@ class BoundWriteStream:
 class StreamOut(ComplexCharacteristic):
     """Output stream from the Service server."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         uuid: Optional[UUID] = None,
@@ -88,7 +87,7 @@ class StreamOut(ComplexCharacteristic):
 class StreamIn(ComplexCharacteristic):
     """Input stream into the Service server."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         uuid: Optional[UUID] = None,

--- a/adafruit_ble/characteristics/string.py
+++ b/adafruit_ble/characteristics/string.py
@@ -12,16 +12,16 @@ This module provides string characteristics.
 
 from __future__ import annotations
 
-from . import Attribute
-from . import Characteristic
+from . import Attribute, Characteristic
 
 try:
-    from typing import Optional, Type, Union, TYPE_CHECKING
+    from typing import TYPE_CHECKING, Optional, Type, Union, overload
 
     if TYPE_CHECKING:
         from circuitpython_typing import ReadableBuffer
-        from adafruit_ble.uuid import UUID
+
         from adafruit_ble.services import Service
+        from adafruit_ble.uuid import UUID
 
 except ImportError:
     pass
@@ -33,7 +33,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class StringCharacteristic(Characteristic):
     """UTF-8 Encoded string characteristic."""
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         uuid: Optional[UUID] = None,
@@ -52,9 +52,21 @@ class StringCharacteristic(Characteristic):
             initial_value=initial_value,
         )
 
+    if TYPE_CHECKING:
+
+        @overload
+        def __get__(
+            self, obj: None, cls: Optional[Type[Service]] = None
+        ) -> Characteristic:
+            ...
+
+        @overload
+        def __get__(self, obj: Service, cls: Optional[Type[Service]] = None) -> str:
+            ...
+
     def __get__(
         self, obj: Optional[Service], cls: Optional[Type[Service]] = None
-    ) -> Union[str, "StringCharacteristic"]:
+    ) -> Union[Characteristic, str]:
         if obj is None:
             return self
         return str(super().__get__(obj, cls), "utf-8")
@@ -77,9 +89,21 @@ class FixedStringCharacteristic(Characteristic):
             fixed_length=True,
         )
 
+    if TYPE_CHECKING:
+
+        @overload
+        def __get__(
+            self, obj: None, cls: Optional[Type[Service]] = None
+        ) -> Characteristic:
+            ...
+
+        @overload
+        def __get__(self, obj: Service, cls: Optional[Type[Service]] = None) -> str:
+            ...
+
     def __get__(
-        self, obj: Service, cls: Optional[Type[Service]] = None
-    ) -> Union[str, "FixedStringCharacteristic"]:
+        self, obj: Optional[Service], cls: Optional[Type[Service]] = None
+    ) -> Union[Characteristic, str]:
         if obj is None:
             return self
         return str(super().__get__(obj, cls), "utf-8")

--- a/adafruit_ble/characteristics/string.py
+++ b/adafruit_ble/characteristics/string.py
@@ -21,7 +21,9 @@ try:
         from circuitpython_typing import ReadableBuffer
 
         from adafruit_ble.services import Service
-        from adafruit_ble.uuid import UUID
+        from adafruit_ble.uuid import StandardUUID, VendorUUID
+
+        Uuid = Union[StandardUUID, VendorUUID]
 
 except ImportError:
     pass
@@ -36,7 +38,7 @@ class StringCharacteristic(Characteristic):
     def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
-        uuid: Optional[UUID] = None,
+        uuid: Optional[Uuid] = None,
         properties: int = Characteristic.READ,
         read_perm: int = Attribute.OPEN,
         write_perm: int = Attribute.OPEN,
@@ -79,7 +81,7 @@ class FixedStringCharacteristic(Characteristic):
     """Fixed strings are set once when bound and unchanged after."""
 
     def __init__(
-        self, *, uuid: Optional[UUID] = None, read_perm: int = Attribute.OPEN
+        self, *, uuid: Optional[Uuid] = None, read_perm: int = Attribute.OPEN
     ) -> None:
         super().__init__(
             uuid=uuid,

--- a/adafruit_ble/characteristics/string.py
+++ b/adafruit_ble/characteristics/string.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from . import Attribute, Characteristic
 
+TYPE_CHECKING = False
 try:
     from typing import TYPE_CHECKING, Optional, Type, Union, overload
 

--- a/adafruit_ble/services/__init__.py
+++ b/adafruit_ble/services/__init__.py
@@ -15,12 +15,14 @@ import _bleio
 from ..characteristics import Characteristic, ComplexCharacteristic
 
 try:
-    from typing import TYPE_CHECKING, Dict, Optional
+    from typing import TYPE_CHECKING, Dict, Optional, Union
 except ImportError:
     pass
 
 if TYPE_CHECKING:
-    from adafruit_ble.uuid import UUID
+    from adafruit_ble.uuid import StandardUUID, VendorUUID
+
+    Uuid = Union[StandardUUID, VendorUUID]
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -39,7 +41,7 @@ class Service:
     instance for the connection's peer.
     """
 
-    uuid: UUID
+    uuid: Uuid
 
     def __init__(
         self,

--- a/adafruit_ble/services/__init__.py
+++ b/adafruit_ble/services/__init__.py
@@ -15,9 +15,12 @@ import _bleio
 from ..characteristics import Characteristic, ComplexCharacteristic
 
 try:
-    from typing import Optional
+    from typing import TYPE_CHECKING, Dict, Optional
 except ImportError:
     pass
+
+if TYPE_CHECKING:
+    from adafruit_ble.uuid import UUID
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -36,6 +39,8 @@ class Service:
     instance for the connection's peer.
     """
 
+    uuid: UUID
+
     def __init__(
         self,
         *,
@@ -44,6 +49,7 @@ class Service:
         **initial_values,
     ) -> None:
         if service is None:
+            # NOTE(elpekenin): when is self.uuid set? __new__?
             # pylint: disable=no-member
             self.bleio_service = _bleio.Service(
                 self.uuid.bleio_uuid, secondary=secondary
@@ -56,7 +62,7 @@ class Service:
         # This internal dictionary is manipulated by the Characteristic descriptors to store their
         # per-Service state. It is NOT managed by the Service itself. It is an attribute of the
         # Service so that the lifetime of the objects is the same as the Service.
-        self.bleio_characteristics = {}
+        self.bleio_characteristics: Dict[str, _bleio.Characteristic] = {}
 
         # Set the field name on all of the characteristic objects so they can replace themselves if
         # they choose.

--- a/adafruit_ble/services/circuitpython.py
+++ b/adafruit_ble/services/circuitpython.py
@@ -10,11 +10,11 @@ This module provides Services defined by CircuitPython. **Out of date.**
 
 """
 
-from . import Service
 from ..characteristics import Characteristic
 from ..characteristics.stream import StreamOut
 from ..characteristics.string import StringCharacteristic
 from ..uuid import VendorUUID
+from . import Service
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"

--- a/adafruit_ble/services/nordic.py
+++ b/adafruit_ble/services/nordic.py
@@ -13,16 +13,16 @@ This module provides Services used by Nordic Semiconductors.
 
 from __future__ import annotations
 
-from . import Service
+from ..characteristics.stream import StreamIn, StreamOut
 from ..uuid import VendorUUID
-from ..characteristics.stream import StreamOut, StreamIn
+from . import Service
 
 try:
-    from typing import Optional, TYPE_CHECKING
+    from typing import TYPE_CHECKING, Optional
 
     if TYPE_CHECKING:
-        from circuitpython_typing import WriteableBuffer, ReadableBuffer
         import _bleio
+        from circuitpython_typing import ReadableBuffer, WriteableBuffer
 
 except ImportError:
     pass

--- a/adafruit_ble/services/sphero.py
+++ b/adafruit_ble/services/sphero.py
@@ -10,8 +10,8 @@ This module provides Services used by Sphero robots.
 
 """
 
-from . import Service
 from ..uuid import VendorUUID
+from . import Service
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"

--- a/adafruit_ble/services/standard/__init__.py
+++ b/adafruit_ble/services/standard/__init__.py
@@ -12,12 +12,11 @@ from __future__ import annotations
 
 import time
 
-from .. import Service
-from ...uuid import StandardUUID
-from ...characteristics import Characteristic
-from ...characteristics.string import StringCharacteristic
-from ...characteristics import StructCharacteristic
+from ...characteristics import Characteristic, StructCharacteristic
 from ...characteristics.int import Uint8Characteristic
+from ...characteristics.string import StringCharacteristic
+from ...uuid import StandardUUID
+from .. import Service
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
@@ -78,7 +77,12 @@ class CurrentTimeService(Service):
         """The current time as a `time.struct_time`. Day of year and whether DST is in effect
         are always -1.
         """
-        year, month, day, hour, minute, second, weekday, _, _ = self.current_time
+        current_time = self.current_time
+        if current_time is None:
+            msg = "Could not get current time."
+            raise RuntimeError(msg)
+
+        year, month, day, hour, minute, second, weekday, _, _ = current_time
         # Bluetooth weekdays count from 1. struct_time counts from 0.
         return time.struct_time(
             (year, month, day, hour, minute, second, weekday - 1, -1, -1)

--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -15,12 +15,12 @@ import binascii
 import os
 import sys
 
-from .. import Service
-from ...uuid import StandardUUID
 from ...characteristics.string import FixedStringCharacteristic
+from ...uuid import StandardUUID
+from .. import Service
 
 try:
-    from typing import Optional, TYPE_CHECKING
+    from typing import TYPE_CHECKING, Optional
 
     if TYPE_CHECKING:
         import _bleio
@@ -43,7 +43,7 @@ class DeviceInfoService(Service):
     software_revision = FixedStringCharacteristic(uuid=StandardUUID(0x2A28))
     manufacturer = FixedStringCharacteristic(uuid=StandardUUID(0x2A29))
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         manufacturer: Optional[str] = None,

--- a/adafruit_ble/services/standard/hid.py
+++ b/adafruit_ble/services/standard/hid.py
@@ -26,7 +26,9 @@ from adafruit_ble.uuid import StandardUUID
 from .. import Service
 
 try:
-    from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union
+    from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+    from typing_extensions import Literal
 
     if TYPE_CHECKING:
         from typing import TypedDict
@@ -220,7 +222,7 @@ class ReportIn:
             initial_value=struct.pack("<BB", self._report_id, _REPORT_TYPE_INPUT),
         )
 
-    def send_report(self, report: Dict) -> None:
+    def send_report(self, report: bytearray) -> None:
         """Send a report to the peers"""
         self._characteristic.value = report
 
@@ -266,7 +268,7 @@ class ReportOut:
         )
 
     @property
-    def report(self) -> Dict:
+    def report(self) -> bytearray:
         """The HID OUT report"""
         return self._characteristic.value
 

--- a/adafruit_ble/uuid/__init__.py
+++ b/adafruit_ble/uuid/__init__.py
@@ -19,9 +19,6 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class UUID:
     """Top level UUID"""
 
-    bleio_uuid: _bleio.UUID
-    size: int
-
     # TODO: Make subclassing _bleio.UUID work so we can just use it directly.
     # pylint: disable=no-member
     def __hash__(self):

--- a/adafruit_ble/uuid/__init__.py
+++ b/adafruit_ble/uuid/__init__.py
@@ -19,6 +19,9 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_BLE.git"
 class UUID:
     """Top level UUID"""
 
+    bleio_uuid: _bleio.UUID
+    size: int
+
     # TODO: Make subclassing _bleio.UUID work so we can just use it directly.
     # pylint: disable=no-member
     def __hash__(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier: MIT
 
+import datetime
 import os
 import sys
-import datetime
 
 sys.path.insert(0, os.path.abspath(".."))
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -123,7 +123,7 @@ htmlhelp_basename = "AdafruitBleLibrarydoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',

--- a/examples/ble_advertising_simpletest.py
+++ b/examples/ble_advertising_simpletest.py
@@ -6,7 +6,6 @@ Simple connectable name advertisement. No services.
 """
 
 from adafruit_ble import BLERadio
-
 from adafruit_ble.advertising import Advertisement
 
 ble = BLERadio()

--- a/examples/ble_bluefruit_color_picker.py
+++ b/examples/ble_bluefruit_color_picker.py
@@ -5,9 +5,8 @@
 
 import board
 import neopixel
-
-from adafruit_bluefruit_connect.packet import Packet
 from adafruit_bluefruit_connect.color_packet import ColorPacket
+from adafruit_bluefruit_connect.packet import Packet
 
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement

--- a/examples/ble_bluefruit_connect_plotter.py
+++ b/examples/ble_bluefruit_connect_plotter.py
@@ -4,9 +4,11 @@
 # CircuitPython Bluefruit LE Connect Plotter Example
 
 import time
-import board
-import analogio
+
 import adafruit_thermistor
+import analogio
+import board
+
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 from adafruit_ble.services.nordic import UARTService

--- a/examples/ble_color_proximity.py
+++ b/examples/ble_color_proximity.py
@@ -77,8 +77,8 @@ while True:
         print("Scanning for colors")
         while not slide_switch.value:
             for entry in ble.start_scan(AdafruitColor, minimum_rssi=-100, timeout=1):
-                if entry.rssi is None:
-                    raise RuntimeError
+                assert isinstance(entry, AdafruitColor)
+                assert entry.rssi is not None
 
                 if slide_switch.value:
                     break

--- a/examples/ble_color_proximity.py
+++ b/examples/ble_color_proximity.py
@@ -8,9 +8,9 @@ slide switch. The buttons change the color when advertising.
 """
 
 import time
+
 import board
 import digitalio
-
 import neopixel
 
 from adafruit_ble import BLERadio

--- a/examples/ble_color_proximity.py
+++ b/examples/ble_color_proximity.py
@@ -73,10 +73,13 @@ while True:
     else:
         closest = None
         closest_rssi = -80
-        closest_last_time = 0
+        closest_last_time: float = 0
         print("Scanning for colors")
         while not slide_switch.value:
             for entry in ble.start_scan(AdafruitColor, minimum_rssi=-100, timeout=1):
+                if entry.rssi is None:
+                    raise RuntimeError
+
                 if slide_switch.value:
                     break
                 now = time.monotonic()

--- a/examples/ble_current_time_service.py
+++ b/examples/ble_current_time_service.py
@@ -15,6 +15,8 @@ from adafruit_ble.services.standard import CurrentTimeService
 radio = adafruit_ble.BLERadio()
 a = SolicitServicesAdvertisement()
 a.complete_name = "TimePlease"
+if not a.solicited_services:
+    raise RuntimeError
 a.solicited_services.append(CurrentTimeService)
 radio.start_advertising(a)
 
@@ -25,10 +27,17 @@ print("connected")
 
 while radio.connected:
     for connection in radio.connections:
+        if connection is None:
+            raise RuntimeError
+
         if not connection.paired:
             connection.pair()
             print("paired")
+
         cts = connection[CurrentTimeService]
+        if cts is None:
+            raise RuntimeError
+
         print(cts.current_time)
     time.sleep(1)
 

--- a/examples/ble_current_time_service.py
+++ b/examples/ble_current_time_service.py
@@ -7,6 +7,7 @@ pairing and then prints the time every second.
 """
 
 import time
+
 import adafruit_ble
 from adafruit_ble.advertising.standard import SolicitServicesAdvertisement
 from adafruit_ble.services.standard import CurrentTimeService

--- a/examples/ble_current_time_service.py
+++ b/examples/ble_current_time_service.py
@@ -15,8 +15,7 @@ from adafruit_ble.services.standard import CurrentTimeService
 radio = adafruit_ble.BLERadio()
 a = SolicitServicesAdvertisement()
 a.complete_name = "TimePlease"
-if not a.solicited_services:
-    raise RuntimeError
+assert a.solicited_services
 a.solicited_services.append(CurrentTimeService)
 radio.start_advertising(a)
 
@@ -27,16 +26,14 @@ print("connected")
 
 while radio.connected:
     for connection in radio.connections:
-        if connection is None:
-            raise RuntimeError
+        assert connection is not None
 
         if not connection.paired:
             connection.pair()
             print("paired")
 
         cts = connection[CurrentTimeService]
-        if cts is None:
-            raise RuntimeError
+        assert isinstance(cts, CurrentTimeService)
 
         print(cts.current_time)
     time.sleep(1)

--- a/examples/ble_demo_central.py
+++ b/examples/ble_demo_central.py
@@ -41,8 +41,7 @@ uart_connection = None
 # See if any existing connections are providing UARTService.
 if ble.connected:
     for connection in ble.connections:
-        if connection is None:
-            raise RuntimeError
+        assert connection is not None
 
         if UARTService in connection:
             uart_connection = connection
@@ -52,6 +51,7 @@ while True:
     if not uart_connection:
         print("Scanning...")
         for adv in ble.start_scan(ProvideServicesAdvertisement, timeout=5):
+            assert isinstance(adv, ProvideServicesAdvertisement)
             if UARTService in adv.services:
                 print("found a UARTService advertisement")
                 uart_connection = ble.connect(adv)
@@ -67,8 +67,8 @@ while True:
         color_packet = ColorPacket(color)
         try:
             service = uart_connection[UARTService]
-            if service is None:
-                raise RuntimeError
+            assert isinstance(service, UARTService)
+
             service.write(color_packet.to_bytes())
         except OSError:
             try:

--- a/examples/ble_demo_central.py
+++ b/examples/ble_demo_central.py
@@ -9,12 +9,11 @@ peripheral.
 
 import time
 
+import adafruit_lis3dh
 import board
 import busio
 import digitalio
-import adafruit_lis3dh
 import neopixel
-
 from adafruit_bluefruit_connect.color_packet import ColorPacket
 
 from adafruit_ble import BLERadio

--- a/examples/ble_demo_central.py
+++ b/examples/ble_demo_central.py
@@ -41,6 +41,9 @@ uart_connection = None
 # See if any existing connections are providing UARTService.
 if ble.connected:
     for connection in ble.connections:
+        if connection is None:
+            raise RuntimeError
+
         if UARTService in connection:
             uart_connection = connection
         break
@@ -63,7 +66,10 @@ while True:
         neopixels.fill(color)
         color_packet = ColorPacket(color)
         try:
-            uart_connection[UARTService].write(color_packet.to_bytes())
+            service = uart_connection[UARTService]
+            if service is None:
+                raise RuntimeError
+            service.write(color_packet.to_bytes())
         except OSError:
             try:
                 uart_connection.disconnect()

--- a/examples/ble_demo_periph.py
+++ b/examples/ble_demo_periph.py
@@ -8,10 +8,10 @@ and updates a Circuit Playground to show the history of the received packets.
 
 import board
 import neopixel
+from adafruit_bluefruit_connect.color_packet import ColorPacket
 
 # Only the packet classes that are imported will be known to Packet.
 from adafruit_bluefruit_connect.packet import Packet
-from adafruit_bluefruit_connect.color_packet import ColorPacket
 
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement

--- a/examples/ble_detailed_scan.py
+++ b/examples/ble_detailed_scan.py
@@ -6,7 +6,6 @@
 # specialty advertising types.
 
 from adafruit_ble import BLERadio
-
 from adafruit_ble.advertising import Advertisement
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 

--- a/examples/ble_device_info_service.py
+++ b/examples/ble_device_info_service.py
@@ -29,10 +29,17 @@ print("connected")
 
 while radio.connected:
     for connection in radio.connections:
+        if connection is None:
+            raise RuntimeError
+
         if not connection.paired:
             connection.pair()
             print("paired")
+
         dis = connection[DeviceInfoService]
+        if dis is None:
+            raise RuntimeError
+
         print(dis.manufacturer)
         print(dis.model_number)
     time.sleep(60)

--- a/examples/ble_device_info_service.py
+++ b/examples/ble_device_info_service.py
@@ -29,16 +29,14 @@ print("connected")
 
 while radio.connected:
     for connection in radio.connections:
-        if connection is None:
-            raise RuntimeError
+        assert connection is not None
 
         if not connection.paired:
             connection.pair()
             print("paired")
 
         dis = connection[DeviceInfoService]
-        if dis is None:
-            raise RuntimeError
+        assert isinstance(dis, DeviceInfoService)
 
         print(dis.manufacturer)
         print(dis.model_number)

--- a/examples/ble_device_info_service.py
+++ b/examples/ble_device_info_service.py
@@ -7,6 +7,7 @@ manufacturer and model number of the device(s) that connect to it.
 """
 
 import time
+
 import adafruit_ble
 from adafruit_ble.advertising.standard import Advertisement
 from adafruit_ble.services.standard.device_info import DeviceInfoService

--- a/examples/ble_hid_periph.py
+++ b/examples/ble_hid_periph.py
@@ -29,8 +29,9 @@ scan_response = Advertisement()
 
 ble = adafruit_ble.BLERadio()
 if ble.connected:
-    for c in ble.connections:
-        c.disconnect()
+    for conn in ble.connections:
+        if conn is not None:
+            conn.disconnect()
 
 print("advertising")
 ble.start_advertising(advertisement, scan_response)
@@ -42,9 +43,9 @@ while True:
         pass
     print("Start typing:")
     while ble.connected:
-        c = sys.stdin.read(1)
-        sys.stdout.write(c)
-        kl.write(c)
+        char = sys.stdin.read(1)
+        sys.stdout.write(char)
+        kl.write(char)
         # print("sleeping")
         time.sleep(0.1)
     ble.start_advertising(advertisement)

--- a/examples/ble_hid_periph.py
+++ b/examples/ble_hid_periph.py
@@ -15,9 +15,8 @@ from adafruit_hid.keyboard_layout_us import KeyboardLayoutUS
 import adafruit_ble
 from adafruit_ble.advertising import Advertisement
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-from adafruit_ble.services.standard.hid import HIDService
 from adafruit_ble.services.standard.device_info import DeviceInfoService
-
+from adafruit_ble.services.standard.hid import HIDService
 
 # Use default HID descriptor
 hid = HIDService()

--- a/examples/ble_json_central.py
+++ b/examples/ble_json_central.py
@@ -5,9 +5,9 @@
 # Read sensor readings from peripheral BLE device using a JSON characteristic.
 
 from ble_json_service import SensorService
+
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-
 
 ble = BLERadio()
 connection = None

--- a/examples/ble_json_central.py
+++ b/examples/ble_json_central.py
@@ -16,6 +16,7 @@ while True:
     if not connection:
         print("Scanning for BLE device advertising our sensor service...")
         for adv in ble.start_scan(ProvideServicesAdvertisement):
+            assert isinstance(adv, ProvideServicesAdvertisement)
             if SensorService in adv.services:
                 connection = ble.connect(adv)
                 print("Connected")
@@ -24,8 +25,7 @@ while True:
 
     if connection and connection.connected:
         service = connection[SensorService]
-        if service is None:
-            raise RuntimeError
+        assert isinstance(service, SensorService)
 
         service.settings = {"unit": "celsius"}  #  'fahrenheit'
         while connection.connected:

--- a/examples/ble_json_central.py
+++ b/examples/ble_json_central.py
@@ -24,6 +24,9 @@ while True:
 
     if connection and connection.connected:
         service = connection[SensorService]
+        if service is None:
+            raise RuntimeError
+
         service.settings = {"unit": "celsius"}  #  'fahrenheit'
         while connection.connected:
             print("Sensors: ", service.sensors)

--- a/examples/ble_json_peripheral.py
+++ b/examples/ble_json_peripheral.py
@@ -4,12 +4,13 @@
 
 # Provide readable sensor values and writable settings to connected devices via JSON characteristic.
 
-import time
 import random
+import time
+
 from ble_json_service import SensorService
+
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
-
 
 # Create BLE radio, custom service, and advertisement.
 ble = BLERadio()

--- a/examples/ble_json_service.py
+++ b/examples/ble_json_service.py
@@ -4,10 +4,10 @@
 
 # Read sensor readings from peripheral BLE device using a JSON characteristic.
 
-from adafruit_ble.uuid import VendorUUID
-from adafruit_ble.services import Service
 from adafruit_ble.characteristics import Characteristic
 from adafruit_ble.characteristics.json import JSONCharacteristic
+from adafruit_ble.services import Service
+from adafruit_ble.uuid import VendorUUID
 
 
 # A custom service with two JSON characteristics for this device.  The "sensors" characteristic

--- a/examples/ble_packet_buffer_client.py
+++ b/examples/ble_packet_buffer_client.py
@@ -17,13 +17,22 @@ ble = BLERadio()
 buf = bytearray(512)
 while True:
     while ble.connected and any(
-        PacketBufferService in connection for connection in ble.connections
+        map(
+            lambda conn: conn is not None and PacketBufferService in conn,
+            ble.connections,
+        )
     ):
         for connection in ble.connections:
+            if connection is None:
+                raise RuntimeError
+
             if PacketBufferService not in connection:
                 continue
             print("echo")
+
             pb = connection[PacketBufferService]
+            if pb is None:
+                raise RuntimeError
             pb.write(b"echo")
             # Returns 0 if nothing was read.
             packet_len = pb.readinto(buf)

--- a/examples/ble_packet_buffer_client.py
+++ b/examples/ble_packet_buffer_client.py
@@ -23,16 +23,15 @@ while True:
         )
     ):
         for connection in ble.connections:
-            if connection is None:
-                raise RuntimeError
+            assert connection is not None
 
             if PacketBufferService not in connection:
                 continue
             print("echo")
 
             pb = connection[PacketBufferService]
-            if pb is None:
-                raise RuntimeError
+            assert isinstance(pb, PacketBufferService)
+
             pb.write(b"echo")
             # Returns 0 if nothing was read.
             packet_len = pb.readinto(buf)
@@ -43,6 +42,7 @@ while True:
 
     print("disconnected, scanning")
     for advertisement in ble.start_scan(ProvideServicesAdvertisement, timeout=1):
+        assert isinstance(advertisement, ProvideServicesAdvertisement)
         if PacketBufferService not in advertisement.services:
             continue
         ble.connect(advertisement)

--- a/examples/ble_packet_buffer_service.py
+++ b/examples/ble_packet_buffer_service.py
@@ -8,12 +8,12 @@ PacketBuffer with.
 
 import _bleio
 
-from adafruit_ble.services import Service
 from adafruit_ble.characteristics import (
     Attribute,
     Characteristic,
     ComplexCharacteristic,
 )
+from adafruit_ble.services import Service
 from adafruit_ble.uuid import VendorUUID
 
 
@@ -30,7 +30,7 @@ class PacketBufferUUID(VendorUUID):
 
 
 class PacketBufferCharacteristic(ComplexCharacteristic):
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         *,
         uuid=None,

--- a/examples/ble_packet_buffer_test.py
+++ b/examples/ble_packet_buffer_test.py
@@ -11,7 +11,6 @@ from packet_buffer_service import PacketBufferService
 from adafruit_ble import BLERadio
 from adafruit_ble.advertising.standard import ProvideServicesAdvertisement
 
-
 ble = BLERadio()
 pbs = PacketBufferService()
 advertisement = ProvideServicesAdvertisement(pbs)

--- a/examples/ble_simpletest.py
+++ b/examples/ble_simpletest.py
@@ -7,12 +7,13 @@ from every device found.
 """
 
 from adafruit_ble import BLERadio
+from adafruit_ble.advertising import Advertisement
 
 ble = BLERadio()
 print("scanning")
 found = set()
 scan_responses = set()
-for advertisement in ble.start_scan():
+for advertisement in ble.start_scan(Advertisement):
     addr = advertisement.address
     if advertisement.scan_response and addr not in scan_responses:
         scan_responses.add(addr)

--- a/examples/ble_uart_echo_client.py
+++ b/examples/ble_uart_echo_client.py
@@ -17,16 +17,15 @@ while True:
         map(lambda conn: conn is not None and UARTService in conn, ble.connections)
     ):
         for connection in ble.connections:
-            if connection is None:
-                raise RuntimeError
+            assert connection is not None
 
             if UARTService not in connection:
                 continue
             print("echo")
 
             uart = connection[UARTService]
-            if uart is None:
-                raise RuntimeError
+            assert isinstance(uart, UARTService)
+
             uart.write(b"echo")
             # Returns b'' if nothing was read.
             one_byte = uart.read(4)
@@ -37,6 +36,7 @@ while True:
 
     print("disconnected, scanning")
     for advertisement in ble.start_scan(ProvideServicesAdvertisement, timeout=1):
+        assert isinstance(advertisement, ProvideServicesAdvertisement)
         if UARTService not in advertisement.services:
             continue
         ble.connect(advertisement)

--- a/examples/ble_uart_echo_client.py
+++ b/examples/ble_uart_echo_client.py
@@ -14,13 +14,19 @@ from adafruit_ble.services.nordic import UARTService
 ble = BLERadio()
 while True:
     while ble.connected and any(
-        UARTService in connection for connection in ble.connections
+        map(lambda conn: conn is not None and UARTService in conn, ble.connections)
     ):
         for connection in ble.connections:
+            if connection is None:
+                raise RuntimeError
+
             if UARTService not in connection:
                 continue
             print("echo")
+
             uart = connection[UARTService]
+            if uart is None:
+                raise RuntimeError
             uart.write(b"echo")
             # Returns b'' if nothing was read.
             one_byte = uart.read(4)

--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -1,3 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Alec Delaney, for Adafruit Industries
 #
 # SPDX-License-Identifier: Unlicense
+
+circuitpython-stubs
+mypy


### PR DESCRIPTION
STILL WIP!!!

For a bit of a background, Im planning to go off the list of open typing issues and fix stuff.  First one in the list was some BLE-related one, and when i cloned it and started working, noticed that `mypy` wasn't ignoring this (`adafruit_ble`) module due to the lack of `py.typed` on it. Then decided to open a quick PR to simply add such empty marker file... But, surprise, typing was **very** broken, so here we are, fixing it ;)

Notes
* Perhaps should undo changes to `optional-requirements.txt`
* Depends on changes i've PRed to the circuitpython repository itself (a couple of wrong type-hints in doc comments in the C code), i locally patched my `circuitpython-stubs` to run the tests
* Added `assert` on some places to concrete `Union` and `Optional` down to one of their options. 
  * There are now a few lines of code running `assert foo is not None`  before doing `foo.bar` on the very next line.
  * I'm retty sure these asserts will not break code that was working until now.
  * Letting you know just in case
* Testing is welcome, i dont have any BLE boards
* `py.typed` will be added on the final commit, when every single file passes the checks

While working on this, i've made a couple upgrades to `pre-commit`'s config
* Add `isort`
* Upgrade `pylint` (old version does not build/install on Py312)
* Add `mypy`

Right now, only a couple errors are left. These, for some reason, are not spotted when running `pre-commit run --all-files` but i get them running `$ mypy adafruit_ble` manually. Would like to know what the cause for this is, maybe related to pre-commit using its own virtual environment....