### PR TITLE
Add PNP ID designation to DeviceInfoService

### DIFF
--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 import binascii
 import os
 import sys
+from collections.abc import Iterable
 
 from .. import Service
 from ...uuid import StandardUUID
+from ...characteristics import StructCharacteristic
 from ...characteristics.string import FixedStringCharacteristic
 
 try:
@@ -42,6 +44,7 @@ class DeviceInfoService(Service):
     hardware_revision = FixedStringCharacteristic(uuid=StandardUUID(0x2A27))
     software_revision = FixedStringCharacteristic(uuid=StandardUUID(0x2A28))
     manufacturer = FixedStringCharacteristic(uuid=StandardUUID(0x2A29))
+    pnp_id = StructCharacteristic("<BHHH", uuid=StandardUUID(0x2A50))
 
     def __init__(
         self,
@@ -52,6 +55,7 @@ class DeviceInfoService(Service):
         serial_number: Optional[str] = None,
         firmware_revision: Optional[str] = None,
         hardware_revision: Optional[str] = None,
+        pnp_id: Optional[Iterable] = None,
         service: Optional[_bleio.Service] = None,
     ) -> None:
         if not service:
@@ -75,5 +79,6 @@ class DeviceInfoService(Service):
             serial_number=serial_number,
             firmware_revision=firmware_revision,
             hardware_revision=hardware_revision,
+            pnp_id=pnp_id,
             service=service,
         )


### PR DESCRIPTION
This PR introduces the `PnP ID` characteristic from the [Device Information Service](https://www.bluetooth.com/specifications/specs/dis-1-2/) specification to `DeviceInfoService`.
Currently, there is no way to specify the Vendor ID and Product ID of the Bluetooth device using CircuitPython which can cause inconveniences when trying to make certain operating systems recognize the Bluetooth peripheral device as a specific product (e.g. an Xbox One S Wireless Controller in macOS).
The changes introduced by this PR will allow a developer to set a 8-bit value and three 16-bit values as illustrated below:

```py
device_info = DeviceInfoService(
    software_revision=adafruit_ble.__version__,
    pnp_id=(0x02, 0x045E, 0x02E0, 0x0100),
)
```

The four values being the Vendor ID source field (8-bits), Vendor ID field (16-bits), Product ID field (16-bits), and Product Version field (16-bits) respectively.