### PR TITLE
Modify to allow multiple reports in an Application collection

### DIFF
--- a/adafruit_ble/services/standard/hid.py
+++ b/adafruit_ble/services/standard/hid.py
@@ -442,24 +442,27 @@ class HIDService(Service):
             usage = collection["locals"][0][0]
             reports = {}
             get_report_info(collection, reports)
-            if len(reports) > 1:
-                raise NotImplementedError(
-                    "Only one report id per Application collection supported"
-                )
-
-            report_id, report = list(reports.items())[0]
-            output_size = report["output_size"]
-            if output_size > 0:
-                self.devices.append(
-                    ReportOut(
-                        self, report_id, usage_page, usage, max_length=output_size // 8
+            for report_id, report in reports:
+                output_size = report["output_size"]
+                if output_size > 0:
+                    self.devices.append(
+                        ReportOut(
+                            self,
+                            report_id,
+                            usage_page,
+                            usage,
+                            max_length=output_size // 8,
+                        )
                     )
-                )
 
-            input_size = reports[report_id]["input_size"]
-            if input_size > 0:
-                self.devices.append(
-                    ReportIn(
-                        self, report_id, usage_page, usage, max_length=input_size // 8
+                input_size = reports[report_id]["input_size"]
+                if input_size > 0:
+                    self.devices.append(
+                        ReportIn(
+                            self,
+                            report_id,
+                            usage_page,
+                            usage,
+                            max_length=input_size // 8,
+                        )
                     )
-                )


### PR DESCRIPTION
This PR removes the single report per Application Collection restriction and registers all descriptors to the `HIDService`.

The change should hopefully resolve https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/136

The following is the code I got to work on macOS Sonoma:
https://gist.github.com/ktnyt/33ad0462a0e7cc49176c78530e320291