### PR TITLE
Use default values when pnp_id is not supplied

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+    rev: v3.3.0
     hooks:
       - id: pylint
         name: pylint (library code)

--- a/.pylintrc
+++ b/.pylintrc
@@ -361,7 +361,8 @@ valid-metaclass-classmethod-first-arg=mcs
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+# Changed for this library, Adafruit_CircuitPython_BLE
+max-args=9
 
 # Maximum number of attributes for a class (see R0902).
 # max-attributes=7

--- a/adafruit_ble/services/standard/device_info.py
+++ b/adafruit_ble/services/standard/device_info.py
@@ -71,6 +71,10 @@ class DeviceInfoService(Service):
                     pass
             if firmware_revision is None:
                 firmware_revision = getattr(os.uname(), "version", None)
+            if pnp_id is None:
+                # These values are not necessarily valid according to the spec,
+                # but they work on Android and iOS.
+                pnp_id = (0x00, 0x0000, 0x0000, 0x0000)
         super().__init__(
             manufacturer=manufacturer,
             software_revision=software_revision,


### PR DESCRIPTION
If `pnp_id` was not supplied, an exception was raised.

Merging this now without a review because otherwise `main` is broken. Tested on iOS and Android.