### PR TITLE
unpin typing-extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 Adafruit-Blinka
 adafruit-blinka-bleio
 adafruit-circuitpython-typing
-typing-extensions~=4.0.0
+typing-extensions


### PR DESCRIPTION
Let `typing-extensions` install the latest version instead of pinned. 

I think this should resolve: #219 